### PR TITLE
Added note about r/w repository access to README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,7 @@ Installation Steps
     + Click on *Pick a template to build*, which will guide you through setting up of a new template
     + Paste your GitHub token
     + Select the path to your SSH keys
+    + Make sure that your account has read and write access to the repository
     + Click Done, which validates the settings and GitHub access
 - In the bottom part, choose the sync interval (default is now 15 seconds, which works pretty well, don't decrease it too much, GitHub rate-limits access to 5000 requests per hour, when authenticated and only 60 when unauthenticated)
 - If both Server and Project configs say *Verified access, all is well*, click **Start** to start syncing your pull requests with bots.


### PR DESCRIPTION
Since we tripped over this (having a read only user for Xcode and Buildasaur) I added a point to the documentation.
