### PR TITLE
GitHub Rate Limiting in the UI now

### DIFF
--- a/BuildaGitServer/GitHubRateLimit.swift
+++ b/BuildaGitServer/GitHubRateLimit.swift
@@ -1,0 +1,38 @@
+//
+//  GitHubRateLimit.swift
+//  Buildasaur
+//
+//  Created by Honza Dvorsky on 03/05/2015.
+//  Copyright (c) 2015 Honza Dvorsky. All rights reserved.
+//
+
+import Foundation
+
+public struct GitHubRateLimit {
+    
+    public let resetTime: Double
+    public let limit: Int
+    public let remaining: Int
+    public let now: Double = NSDate().timeIntervalSince1970
+    
+    public func getReport() -> String {
+        
+        let resetInterval = 3600.0 //reset interval is 1 hour
+        let startTime = self.resetTime - resetInterval
+        let remainingTime = self.resetTime - self.now
+        let consumed = self.limit - self.remaining
+        let consumedTime = self.now - startTime
+        let rateOfConsumption = Double(consumed) / consumedTime
+        let rateOfConsumptionPretty = rateOfConsumption.clipTo(2)
+        let maxRateOfConsumption = Double(self.limit) / resetInterval
+        let maxRateOfConsumptionPretty = maxRateOfConsumption.clipTo(2)
+        
+        //how much faster we can be consuming requests before we hit the maximum rate of 5000/hour
+        let extraRateOfConsumption = (maxRateOfConsumption - rateOfConsumption).clipTo(2)
+        let usedRatePercent = (100.0 * rateOfConsumption / maxRateOfConsumption).clipTo(2)
+        
+        let report = "count: \(consumed)/\(self.limit), renews in \(Int(remainingTime)) seconds, rate: \(rateOfConsumptionPretty)/\(maxRateOfConsumptionPretty), using \(usedRatePercent)% of the allowed request rate."
+        return report
+    }
+    
+}

--- a/BuildaGitServer/GitHubServer.swift
+++ b/BuildaGitServer/GitHubServer.swift
@@ -12,7 +12,8 @@ import BuildaUtils
 public class GitHubServer : GitServer {
     
     public let endpoints: GitHubEndpoints
-    
+    public var latestRateLimitInfo: GitHubRateLimit?
+
     public init(endpoints: GitHubEndpoints, http: HTTP? = nil) {
         
         self.endpoints = endpoints
@@ -130,29 +131,15 @@ extension GitHubServer {
             
             if let response = response {
                 let headers = response.allHeaderFields
-                let now = NSDate().timeIntervalSince1970
                 
                 if
                     let resetTime = (headers["X-RateLimit-Reset"] as? NSString)?.doubleValue,
                     let limit = (headers["X-RateLimit-Limit"] as? NSString)?.integerValue,
                     let remaining = (headers["X-RateLimit-Remaining"] as? NSString)?.integerValue {
                         
-                        let resetInterval = 3600.0 //reset interval is 1 hour
-                        let startTime = resetTime - resetInterval
-                        let remainingTime = resetTime - now
-                        let consumed = limit - remaining
-                        let consumedTime = now - startTime
-                        let rateOfConsumption = Double(consumed) / consumedTime
-                        let rateOfConsumptionPretty = rateOfConsumption.clipTo(2)
-                        let maxRateOfConsumption = Double(limit) / resetInterval
-                        let maxRateOfConsumptionPretty = maxRateOfConsumption.clipTo(2)
-                        
-                        //how much faster we can be consuming requests before we hit the maximum rate of 5000/hour
-                        let extraRateOfConsumption = (maxRateOfConsumption - rateOfConsumption).clipTo(2)
-                        let usedRatePercent = (100.0 * rateOfConsumption / maxRateOfConsumption).clipTo(2)
-                        
-                        Log.info("GitHub Rate limit; count: \(consumed)/\(limit), renews in \(Int(remainingTime)) seconds, rate: \(rateOfConsumptionPretty)/\(maxRateOfConsumptionPretty), using \(usedRatePercent)% of requests per time.")
-                        
+                        let rateLimitInfo = GitHubRateLimit(resetTime: resetTime, limit: limit, remaining: remaining)
+                        self.latestRateLimitInfo = rateLimitInfo
+
                 } else {
                     Log.error("No X-RateLimit info provided by GitHub in headers: \(headers), we're unable to detect the remaining number of allowed requests. GitHub might fail to return data any time now :(")
                 }

--- a/Buildasaur.xcodeproj/project.pbxproj
+++ b/Buildasaur.xcodeproj/project.pbxproj
@@ -15,6 +15,7 @@
 		3A32CD1E1A3D2ADD00861A34 /* GitHubServerExtensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3A32CD1D1A3D2ADD00861A34 /* GitHubServerExtensions.swift */; };
 		3A331C411A940C8D0005AA98 /* CommonExtensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3A331C401A940C8D0005AA98 /* CommonExtensions.swift */; };
 		3A3BDC1D1AF6C51900D2CD99 /* Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3A3BDC1C1AF6C51900D2CD99 /* Extensions.swift */; };
+		3A3BDC1F1AF6D34900D2CD99 /* GitHubRateLimit.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3A3BDC1E1AF6D34900D2CD99 /* GitHubRateLimit.swift */; };
 		3A4770A21A745F470016E170 /* StorageUtils.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3A4770A11A745F470016E170 /* StorageUtils.swift */; };
 		3A4770A41A745FFA0016E170 /* XcodeProjectParser.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3A4770A31A745FFA0016E170 /* XcodeProjectParser.swift */; };
 		3A5591561A913C0A00FB19F2 /* XcodeLocalSource.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3A5591551A913C0A00FB19F2 /* XcodeLocalSource.swift */; };
@@ -158,6 +159,7 @@
 		3A331C401A940C8D0005AA98 /* CommonExtensions.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = CommonExtensions.swift; sourceTree = "<group>"; };
 		3A38CF951A3CE94C00F41AFA /* Status.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = Status.swift; path = BuildaGitServer/Status.swift; sourceTree = SOURCE_ROOT; };
 		3A3BDC1C1AF6C51900D2CD99 /* Extensions.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Extensions.swift; sourceTree = "<group>"; };
+		3A3BDC1E1AF6D34900D2CD99 /* GitHubRateLimit.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = GitHubRateLimit.swift; sourceTree = "<group>"; };
 		3A4770A11A745F470016E170 /* StorageUtils.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = StorageUtils.swift; sourceTree = "<group>"; };
 		3A4770A31A745FFA0016E170 /* XcodeProjectParser.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = XcodeProjectParser.swift; sourceTree = "<group>"; };
 		3A4770A51A746BC00016E170 /* Buildasaur.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.xml; path = Buildasaur.entitlements; sourceTree = "<group>"; };
@@ -339,6 +341,7 @@
 				3A6355D91A3BBDA500545BF9 /* GitHubFactory.swift */,
 				3A58B1521A3B967C003E0266 /* GitHubServer.swift */,
 				3A32CD1D1A3D2ADD00861A34 /* GitHubServerExtensions.swift */,
+				3A3BDC1E1AF6D34900D2CD99 /* GitHubRateLimit.swift */,
 			);
 			name = GitHub;
 			path = BuildaGitServer;
@@ -803,6 +806,7 @@
 				3AB3F0E41A3CEBAC005F717F /* PullRequestBranch.swift in Sources */,
 				3AB3F0E61A3CEBAC005F717F /* User.swift in Sources */,
 				3AB3F0E91A3CEBAC005F717F /* GitHubFactory.swift in Sources */,
+				3A3BDC1F1AF6D34900D2CD99 /* GitHubRateLimit.swift in Sources */,
 				3A32CD1E1A3D2ADD00861A34 /* GitHubServerExtensions.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/Buildasaur/Base.lproj/Main.storyboard
+++ b/Buildasaur/Base.lproj/Main.storyboard
@@ -1835,9 +1835,9 @@
                                 </textFieldCell>
                             </textField>
                             <textField verticalHuggingPriority="750" horizontalCompressionResistancePriority="250" setsMaxLayoutWidthAtFirstLayout="YES" translatesAutoresizingMaskIntoConstraints="NO" id="8VZ-bw-dT5">
-                                <rect key="frame" x="212" y="8" width="401" height="120"/>
+                                <rect key="frame" x="212" y="8" width="401" height="135"/>
                                 <constraints>
-                                    <constraint firstAttribute="height" relation="greaterThanOrEqual" constant="120" id="JhA-5r-PLq"/>
+                                    <constraint firstAttribute="height" relation="greaterThanOrEqual" constant="135" id="JhA-5r-PLq"/>
                                 </constraints>
                                 <textFieldCell key="cell" sendsActionOnEndEditing="YES" title="Multiline Label" id="4Nm-0d-uud">
                                     <font key="font" metaFont="system"/>
@@ -1846,7 +1846,7 @@
                                 </textFieldCell>
                             </textField>
                             <button verticalHuggingPriority="750" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="JKR-Sp-m8Y">
-                                <rect key="frame" x="20" y="109" width="169" height="19"/>
+                                <rect key="frame" x="20" y="124" width="169" height="19"/>
                                 <buttonCell key="cell" type="roundTextured" title="Manual Bot Management" bezelStyle="texturedRounded" alignment="center" controlSize="small" state="on" borderStyle="border" imageScaling="proportionallyDown" inset="2" id="hR5-Ym-8aa">
                                     <behavior key="behavior" pushIn="YES" lightByBackground="YES" lightByGray="YES"/>
                                     <font key="font" metaFont="smallSystem"/>
@@ -1857,7 +1857,7 @@
                             </button>
                         </subviews>
                         <constraints>
-                            <constraint firstItem="8VZ-bw-dT5" firstAttribute="top" secondItem="zNe-bD-Pj4" secondAttribute="top" constant="20" id="Idf-Wk-1a9"/>
+                            <constraint firstItem="8VZ-bw-dT5" firstAttribute="top" secondItem="zNe-bD-Pj4" secondAttribute="top" constant="5" id="Idf-Wk-1a9"/>
                             <constraint firstAttribute="trailing" secondItem="8VZ-bw-dT5" secondAttribute="trailing" constant="7" id="KhO-CN-dKQ"/>
                             <constraint firstAttribute="centerY" secondItem="Fkq-gK-hvs" secondAttribute="centerY" id="Tyj-fy-PKg"/>
                             <constraint firstAttribute="bottom" secondItem="8VZ-bw-dT5" secondAttribute="bottom" constant="8" id="VKM-vY-EPh"/>

--- a/Buildasaur/HDGitHubXCBotSyncer.swift
+++ b/Buildasaur/HDGitHubXCBotSyncer.swift
@@ -96,7 +96,17 @@ public class HDGitHubXCBotSyncer : Syncer {
                             
                             self.reports["All Bots"] = "\(bots.count)"
                             
-                            self.resolvePRsAndBots(repoName: repoName, prs: prs, bots: bots, completion: completion)
+                            self.resolvePRsAndBots(repoName: repoName, prs: prs, bots: bots, completion: {
+                                
+                                if let rateLimitInfo = self.github.latestRateLimitInfo {
+                                    
+                                    let report = rateLimitInfo.getReport()
+                                    self.reports["GitHub Rate Limit"] = report
+                                    Log.info("GitHub Rate Limit: \(report)")
+                                }
+                                
+                                completion()
+                            })
                         } else {
                             self.notifyError(Errors.errorWithInfo("Nil bots even when error was nil"), context: "Fetching Bots")
                             completion()

--- a/Buildasaur/Syncer.swift
+++ b/Buildasaur/Syncer.swift
@@ -112,7 +112,7 @@ public protocol SyncerDelegate: class {
                 self.lastSyncError = nil
                 self.lastSuccessfulSyncFinishedDate = NSDate()
             }
-            Log.info("Sync finished \(finishState) at \(end), took \(end.timeIntervalSinceDate(start)) seconds.")
+            Log.info("Sync finished \(finishState) at \(end), took \(end.timeIntervalSinceDate(start).clipTo(3)) seconds.")
             self.isSyncing = false
         }
     }


### PR DESCRIPTION
added rate limit info in the UI and in the log, fixes #17. we can optimize how many full requests to GitHub with some local caches and conditional requests as part of #12.
