### PR TITLE
Fixed repo permissions check

### DIFF
--- a/Buildasaur/NetworkUtils.swift
+++ b/Buildasaur/NetworkUtils.swift
@@ -35,12 +35,16 @@ class NetworkUtils {
                     let writePermission = repo.permissions["push"] as? Bool
                 {
 
-                    let hasPermissions = readPermission && writePermission
-                    
                     //look at the permissions in the PR metadata
-                    completion(success: hasPermissions, error: nil)
+                    if !readPermission {
+                        completion(success: false, error: Errors.errorWithInfo("Missing read permission for repo"))
+                    } else if !writePermission {
+                        completion(success: false, error: Errors.errorWithInfo("Missing write permission for repo"))
+                    } else {
+                        completion(success: true, error: nil)
+                    }
                 } else {
-                    completion(success: false, error: nil)
+                    completion(success: false, error: Errors.errorWithInfo("Couldn't find repo permissions in GitHub response"))
                 }
             })
             

--- a/Buildasaur/StatusProjectViewController.swift
+++ b/Buildasaur/StatusProjectViewController.swift
@@ -121,11 +121,7 @@ class StatusProjectViewController: StatusViewController, NSComboBoxDelegate, Set
                 if success {
                     status = .Succeeded
                 } else {
-                    if let error = error {
-                        Log.error("Checking github availability error: \(error)")
-                    } else {
-                        Log.error("Checking github availability error: Unknown error")
-                    }
+                    Log.error("Checking github availability error: " + (error?.description ?? "Unknown error"))
                     status = AvailabilityCheckState.Failed(error)
                 }
                 

--- a/Buildasaur/StatusProjectViewController.swift
+++ b/Buildasaur/StatusProjectViewController.swift
@@ -118,11 +118,15 @@ class StatusProjectViewController: StatusViewController, NSComboBoxDelegate, Set
             NetworkUtils.checkAvailabilityOfGitHubWithCurrentSettingsOfProject(self.project()!, completion: { (success, error) -> () in
                 
                 let status: AvailabilityCheckState
-                if let error = error {
-                    Log.error("Checking github availability error: \(error)")
-                    status = AvailabilityCheckState.Failed(error)
-                } else {
+                if success {
                     status = .Succeeded
+                } else {
+                    if let error = error {
+                        Log.error("Checking github availability error: \(error)")
+                    } else {
+                        Log.error("Checking github availability error: Unknown error")
+                    }
+                    status = AvailabilityCheckState.Failed(error)
                 }
                 
                 NSOperationQueue.mainQueue().addOperationWithBlock({ () -> Void in


### PR DESCRIPTION
While testing #15 I
Unfortunately the fix for issue #15 doesn't work correctly because when `NetworkUtils.checkAvailabilityOfGitHubWithCurrentSettingsOfProject` is called, success is not evaluated (see [Line 121 of StatusProjectViewController.swift](https://github.com/czechboy0/Buildasaur/blob/master/Buildasaur/StatusProjectViewController.swift#L121)).
Because the error in this case is empty as well (`completion(success: hasPermissions, error: nil)`) the success code path is taken.

I rewrote the check in the controller to prevent this in the future (though I'm not totally happy with the code duplication for the logging).
I also added errors for all cases where success is false.
