### PR TITLE
Shared schemes in workspace fix

### DIFF
--- a/BuildaUtils/XcodeProjectParser.swift
+++ b/BuildaUtils/XcodeProjectParser.swift
@@ -92,10 +92,14 @@ public class XcodeProjectParser {
     
     public class func sharedSchemeUrlsFromProjectOrWorkspaceUrl(url: NSURL) -> [NSURL] {
         
-        let projectUrls: [NSURL]
+        var projectUrls: [NSURL]
         if self.isWorkspaceUrl(url) {
             //first parse project urls from workspace contents
             projectUrls = self.projectUrlsFromWorkspace(url) ?? [NSURL]()
+            
+            //also add the workspace's url, it might own some schemes as well
+            projectUrls.append(url)
+            
         } else {
             //this already is a project url, take just that
             projectUrls = [url]


### PR DESCRIPTION
Fixed an issue where shared schemes contained in the workspace would not get detected.

Fixes #38 

Thanks, @mikewoodworth!
