### PR TITLE
SSH Key Validation in onboarding

### DIFF
--- a/BuildaUtils/Extensions.swift
+++ b/BuildaUtils/Extensions.swift
@@ -16,3 +16,15 @@ public extension Double {
         return Double(Int(self * multiplier)) / multiplier
     }
 }
+
+public extension String {
+    
+    public func stripTrailingNewline() -> String {
+        
+        var stripped = self
+        if stripped.hasSuffix("\n") {
+            stripped.removeAtIndex(stripped.endIndex.predecessor())
+        }
+        return stripped
+    }
+}

--- a/BuildaUtils/SSHKeyVerification.swift
+++ b/BuildaUtils/SSHKeyVerification.swift
@@ -1,0 +1,31 @@
+//
+//  SSHKeyVerification.swift
+//  Buildasaur
+//
+//  Created by Honza Dvorsky on 13/05/15.
+//  Copyright (c) 2015 Honza Dvorsky. All rights reserved.
+//
+
+import Foundation
+
+public class SSHKeyVerification {
+    
+    public class func verifyKeys(path: String, repoSSHUrl: String) -> Script.ScriptResponse {
+        
+        //create a temp script, because NSTask is being difficult and doesn't play nice with environment variables,
+        //which we need for forcing SSH keys from a specific path to verify they are valid for your repo. sigh.
+        let uuid = NSUUID().UUIDString
+        let tempPath = NSTemporaryDirectory().stringByAppendingPathComponent(uuid)
+        let script = "GIT_SSH_COMMAND='ssh -i \(path)' git ls-remote \(repoSSHUrl)\n"
+        
+        var error: NSError?
+        let success = script.writeToFile(tempPath, atomically: true, encoding: NSUTF8StringEncoding, error: &error)
+        
+        //something like GIT_SSH_COMMAND='ssh -i /path/to/keys' git ls-remote git@github.com:owner/repo.git
+        let r = Script.run("bash", arguments: [tempPath])
+        
+        //delete the temp script
+        NSFileManager.defaultManager().removeItemAtPath(tempPath, error: nil)
+        return r
+    }
+}

--- a/BuildaUtils/Script.swift
+++ b/BuildaUtils/Script.swift
@@ -16,10 +16,10 @@ public class Script {
     
     //TODO: create a small project for this and github+pod it, I couldn't find a simple library for running
     //terminal scripts from Mac apps in Swift. might be useful to other people.
-    public class func run(name: String, arguments: [String]) -> ScriptResponse {
+    public class func run(name: String, arguments: [String] = [], environment: [String: String] = [:]) -> ScriptResponse {
         
         //first resolve the name of the script to a path with `which`
-        let resolved = self.runResolved("/usr/bin/which", arguments: [name])
+        let resolved = self.runResolved("/usr/bin/which", arguments: [name], environment: [:])
         
         //which returns the path + \n, so strip the newline
         var path = resolved.standardOutput.stripTrailingNewline()
@@ -30,11 +30,11 @@ public class Script {
         }
         
         //ok, we have a valid path, run the script
-        let result = self.runResolved(path, arguments: arguments)
+        let result = self.runResolved(path, arguments: arguments, environment: environment)
         return result
     }
     
-    private class func runResolved(path: String, arguments: [String]) -> ScriptResponse {
+    private class func runResolved(path: String, arguments: [String], environment: [String: String]) -> ScriptResponse {
         
         let pid = NSProcessInfo.processInfo().processIdentifier
         
@@ -47,6 +47,12 @@ public class Script {
         let task = NSTask()
         task.launchPath = path
         task.arguments = arguments
+        
+        var env = NSProcessInfo.processInfo().environment
+        for (let index, let keyValue) in enumerate(environment) {
+            env[keyValue.0] = keyValue.1
+        }
+        task.environment = env
         task.standardOutput = outputPipe
         task.standardError = errorPipe
         

--- a/BuildaUtils/Script.swift
+++ b/BuildaUtils/Script.swift
@@ -1,0 +1,75 @@
+//
+//  Script.swift
+//  Buildasaur
+//
+//  Created by Honza Dvorsky on 12/05/15.
+//  Copyright (c) 2015 Honza Dvorsky. All rights reserved.
+//
+
+import Foundation
+
+public class Script {
+    
+    public typealias ScriptResponse = (terminationStatus: Int, standardOutput: String, standardError: String)
+    
+    //TODO: create a small project for this and github+pod it, I couldn't find a simple library for running
+    //terminal scripts from Mac apps in Swift. might be useful to other people.
+    public func run(name: String, arguments: [String]) -> ScriptResponse {
+        
+        //first resolve the name of the script to a path with `which`
+        let resolved = self.runResolved("/usr/bin/which", arguments: [name])
+        let path = resolved.standardOutput
+        
+        //if resolving failed, just abort and propagate the failed run up
+        if (resolved.terminationStatus != 0) || (count(path) == 0) {
+            return resolved
+        }
+        
+        //ok, we have a valid path, run the script
+        let result = self.runResolved(path, arguments: arguments)
+        return result
+    }
+    
+    private func runResolved(path: String, arguments: [String]) -> ScriptResponse {
+        
+        //find path of script "name" with which
+        if name == "/usr/bin"
+        let path =
+        let pid = NSProcessInfo.processInfo().processIdentifier
+        
+        let outputPipe = NSPipe()
+        let errorPipe = NSPipe()
+        
+        let outputFile = outputPipe.fileHandleForReading
+        let errorFile = errorPipe.fileHandleForReading
+        
+        let task = NSTask()
+        task.launchPath = path
+        task.arguments = arguments
+        task.standardOutput = pipe
+        task.standardError = pipe
+        
+        task.launch()
+        
+        //blocks until script finishes.
+        //TODO: think about edge cases and long running/hangings tasks - some sort of a timeout?
+        task.waitUntilExit()
+        
+        let data = file.readDataToEndOfFile()
+        file.closeFile()
+        
+        let output = NSString(data: data, encoding: NSUTF8StringEncoding)
+        println("output: \(output)")
+    }
+    
+    private func stringFromFileAndClose(file: NSFileHandle) -> String {
+        
+        let data = file.readDataToEndOfFile()
+        file.closeFile()
+        let output = NSString(data: data, encoding: NSUTF8StringEncoding) as String?
+        return output ?? ""
+    }
+    
+
+}
+

--- a/BuildaUtils/Script.swift
+++ b/BuildaUtils/Script.swift
@@ -16,11 +16,13 @@ public class Script {
     
     //TODO: create a small project for this and github+pod it, I couldn't find a simple library for running
     //terminal scripts from Mac apps in Swift. might be useful to other people.
-    public func run(name: String, arguments: [String]) -> ScriptResponse {
+    public class func run(name: String, arguments: [String]) -> ScriptResponse {
         
         //first resolve the name of the script to a path with `which`
         let resolved = self.runResolved("/usr/bin/which", arguments: [name])
-        let path = resolved.standardOutput
+        
+        //which returns the path + \n, so strip the newline
+        var path = resolved.standardOutput.stripTrailingNewline()
         
         //if resolving failed, just abort and propagate the failed run up
         if (resolved.terminationStatus != 0) || (count(path) == 0) {
@@ -32,7 +34,7 @@ public class Script {
         return result
     }
     
-    private func runResolved(path: String, arguments: [String]) -> ScriptResponse {
+    private class func runResolved(path: String, arguments: [String]) -> ScriptResponse {
         
         let pid = NSProcessInfo.processInfo().processIdentifier
         
@@ -61,7 +63,7 @@ public class Script {
         return (terminationStatus, output, error)
     }
     
-    private func stringFromFileAndClose(file: NSFileHandle) -> String {
+    private class func stringFromFileAndClose(file: NSFileHandle) -> String {
         
         let data = file.readDataToEndOfFile()
         file.closeFile()

--- a/BuildaUtils/Script.swift
+++ b/BuildaUtils/Script.swift
@@ -8,6 +8,8 @@
 
 import Foundation
 
+//TODO: think about adding support for asynchronous running of scripts as well
+
 public class Script {
     
     public typealias ScriptResponse = (terminationStatus: Int, standardOutput: String, standardError: String)
@@ -32,9 +34,6 @@ public class Script {
     
     private func runResolved(path: String, arguments: [String]) -> ScriptResponse {
         
-        //find path of script "name" with which
-        if name == "/usr/bin"
-        let path =
         let pid = NSProcessInfo.processInfo().processIdentifier
         
         let outputPipe = NSPipe()
@@ -46,8 +45,8 @@ public class Script {
         let task = NSTask()
         task.launchPath = path
         task.arguments = arguments
-        task.standardOutput = pipe
-        task.standardError = pipe
+        task.standardOutput = outputPipe
+        task.standardError = errorPipe
         
         task.launch()
         
@@ -55,11 +54,11 @@ public class Script {
         //TODO: think about edge cases and long running/hangings tasks - some sort of a timeout?
         task.waitUntilExit()
         
-        let data = file.readDataToEndOfFile()
-        file.closeFile()
-        
-        let output = NSString(data: data, encoding: NSUTF8StringEncoding)
-        println("output: \(output)")
+        let terminationStatus = Int(task.terminationStatus)
+        let output = self.stringFromFileAndClose(outputFile)
+        let error = self.stringFromFileAndClose(errorFile)
+    
+        return (terminationStatus, output, error)
     }
     
     private func stringFromFileAndClose(file: NSFileHandle) -> String {
@@ -69,7 +68,5 @@ public class Script {
         let output = NSString(data: data, encoding: NSUTF8StringEncoding) as String?
         return output ?? ""
     }
-    
-
 }
 

--- a/BuildaUtilsTests/Info.plist
+++ b/BuildaUtilsTests/Info.plist
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>CFBundleDevelopmentRegion</key>
+	<string>en</string>
+	<key>CFBundleExecutable</key>
+	<string>$(EXECUTABLE_NAME)</string>
+	<key>CFBundleIdentifier</key>
+	<string>com.swiftkey.$(PRODUCT_NAME:rfc1034identifier)</string>
+	<key>CFBundleInfoDictionaryVersion</key>
+	<string>6.0</string>
+	<key>CFBundleName</key>
+	<string>$(PRODUCT_NAME)</string>
+	<key>CFBundlePackageType</key>
+	<string>BNDL</string>
+	<key>CFBundleShortVersionString</key>
+	<string>1.0</string>
+	<key>CFBundleSignature</key>
+	<string>????</string>
+	<key>CFBundleVersion</key>
+	<string>1</string>
+</dict>
+</plist>

--- a/BuildaUtilsTests/ScriptTests.swift
+++ b/BuildaUtilsTests/ScriptTests.swift
@@ -42,22 +42,39 @@ class ScriptTests: XCTestCase {
         XCTAssertEqual(r, expectedWhichPath, "Which is assumed to be in \(expectedWhichPath)")
     }
     
-    func testBuildasaurReachabilityWithGit() {
-        
-        let response = Script.run("/usr/bin/git", arguments: ["ls-remote", "git@github.com:czechboy0/Buildasaur.git"])
-        let r = response.standardOutput
-        XCTAssertEqual(response.terminationStatus, 0)
-        XCTAssertEqual(response.standardError, "")
-        XCTAssert(count(r) > 0, "Output must be nonempty")
-    }
-    
-    func testUnknownReachabilityWithGit() {
-        
-        let response = Script.run("/usr/bin/git", arguments: ["ls-remote", "git@github.com:czechboy1/dummy.git"])
-        let r = response.standardOutput
-        XCTAssertEqual(response.terminationStatus, 128)
-        XCTAssert(response.standardError.hasPrefix("ERROR"), "Error output should provide error")
-        XCTAssertEqual(response.standardOutput, "", "Standard output should be empty")
-    }
+    //TODO: look into creating temp keys for test process, currently ssh-keygen fails for whatever reason when
+    //ran as a test process but works from the command line. sigh.
+//    func withTemporaryKeys(block: (keyPath: String) -> ()) {
+//        
+//        //create temp SSH keys
+//        let temp = NSHomeDirectory().stringByAppendingPathComponent("mykeys")
+//        let tempResp = Script.run("ssh-keygen", arguments: ["-t", "rsa", "-N", "" ,"-f", "\"\(temp)\""])
+//        block(keyPath: temp)
+//        NSFileManager.defaultManager().removeItemAtPath(temp, error: nil)
+//    }
+//    
+//    func testBuildasaurReachabilityWithGit() {
+//        
+//        self.withTemporaryKeys { (keyPath: String) -> () in
+//            
+//            let r = SSHKeyVerification.verifyKeys(keyPath, repoSSHUrl: "git@github.com:czechboy0/Buildasaur.git")
+//            let response = r.standardOutput
+//            XCTAssertEqual(r.terminationStatus, 0)
+//            XCTAssertEqual(r.standardError, "")
+//            XCTAssert(count(response) > 0, "Output must be nonempty")
+//        }
+//    }
+//    
+//    func testUnknownReachabilityWithGit() {
+//        
+//        self.withTemporaryKeys { (keyPath: String) -> () in
+//            
+//            let response = SSHKeyVerification.verifyKeys(keyPath, repoSSHUrl: "git@github.com:czechboy0/dummy.git")
+//            let r = response.standardOutput
+//            XCTAssertEqual(response.terminationStatus, 128)
+//            XCTAssert(response.standardError.hasPrefix("ERROR"), "Error output should provide error")
+//            XCTAssertEqual(response.standardOutput, "", "Standard output should be empty")
+//        }
+//    }
     
 }

--- a/BuildaUtilsTests/ScriptTests.swift
+++ b/BuildaUtilsTests/ScriptTests.swift
@@ -1,0 +1,59 @@
+//
+//  ScriptTests.swift
+//  Buildasaur
+//
+//  Created by Honza Dvorsky on 12/05/15.
+//  Copyright (c) 2015 Honza Dvorsky. All rights reserved.
+//
+
+import Foundation
+import XCTest
+import BuildaUtils
+
+class ScriptTests: XCTestCase {
+    
+    func testGitVersion() {
+        
+        //here we have to specify the exact path, unfortunately `which git` leads to the prebundled git in xcode
+        //whereas when you run Buildasaur normally (under your user), `which git` will do what you'd expect, choose
+        //your active git binary (probably in /usr/bin/git or /usr/local/bin/git
+        
+        let response = Script.run("/usr/bin/git", arguments: ["--version"])
+        XCTAssertEqual(response.terminationStatus, 0)
+        XCTAssertEqual(response.standardError, "")
+        
+        let versionString = response.standardOutput
+        XCTAssert(count(versionString) > 0, "Git version must not be an empty string")
+        
+        let comps = versionString.componentsSeparatedByString(" ")
+        let version = comps[2]
+        XCTAssertGreaterThanOrEqual(version, "2.3.0", "Git version must be at least 2.3")
+    }
+    
+    func testWhich() {
+        
+        let response = Script.run("which", arguments: ["which"])
+        let expectedWhichPath = "/usr/bin/which"
+        let r = response.standardOutput.stripTrailingNewline()
+        XCTAssertEqual(r, expectedWhichPath, "Which is assumed to be in \(expectedWhichPath)")
+    }
+    
+    func testBuildasaurReachabilityWithGit() {
+        
+        let response = Script.run("/usr/bin/git", arguments: ["ls-remote", "git@github.com:czechboy0/Buildasaur.git"])
+        let r = response.standardOutput
+        XCTAssertEqual(response.terminationStatus, 0)
+        XCTAssertEqual(response.standardError, "")
+        XCTAssert(count(r) > 0, "Output must be nonempty")
+    }
+    
+    func testUnknownReachabilityWithGit() {
+        
+        let response = Script.run("/usr/bin/git", arguments: ["ls-remote", "git@github.com:czechboy1/dummy.git"])
+        let r = response.standardOutput
+        XCTAssertEqual(response.terminationStatus, 128)
+        XCTAssert(response.standardError.hasPrefix("ERROR"), "Error output should provide error")
+        XCTAssertEqual(response.standardOutput, "", "Standard output should be empty")
+    }
+    
+}

--- a/BuildaUtilsTests/ScriptTests.swift
+++ b/BuildaUtilsTests/ScriptTests.swift
@@ -26,8 +26,12 @@ class ScriptTests: XCTestCase {
         XCTAssert(count(versionString) > 0, "Git version must not be an empty string")
         
         let comps = versionString.componentsSeparatedByString(" ")
-        let version = comps[2]
-        XCTAssertGreaterThanOrEqual(version, "2.3.0", "Git version must be at least 2.3")
+        XCTAssertGreaterThanOrEqual(comps.count, 3)
+        
+        if comps.count >= 3 {
+            let version = comps[2]
+            XCTAssertGreaterThanOrEqual(version, "2.3.0", "Git version must be at least 2.3")            
+        }
     }
     
     func testWhich() {

--- a/Buildasaur.xcodeproj/project.pbxproj
+++ b/Buildasaur.xcodeproj/project.pbxproj
@@ -8,6 +8,9 @@
 
 /* Begin PBXBuildFile section */
 		3A1546461B02A0C6001EEB45 /* Script.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3A1546451B02A0C6001EEB45 /* Script.swift */; };
+		3A1546511B02A32C001EEB45 /* BuildaUtils.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 3AAF6E741A3CE4CC00C657FB /* BuildaUtils.framework */; };
+		3A15465B1B02A37D001EEB45 /* ScriptTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3A15465A1B02A37D001EEB45 /* ScriptTests.swift */; };
+		3A15465F1B02A4CE001EEB45 /* Info.plist in Resources */ = {isa = PBXBuildFile; fileRef = 3A15465E1B02A4CE001EEB45 /* Info.plist */; };
 		3A2F9D821A8FE5D700B0DB68 /* StorageManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3A2F9D811A8FE5D700B0DB68 /* StorageManager.swift */; };
 		3A2F9D861A8FE64900B0DB68 /* LocalSource.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3A2F9D841A8FE64900B0DB68 /* LocalSource.swift */; };
 		3A2F9D871A8FE64900B0DB68 /* Syncer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3A2F9D851A8FE64900B0DB68 /* Syncer.swift */; };
@@ -83,6 +86,13 @@
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
+		3A1546521B02A32C001EEB45 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 3A5687681A3B93BD0066DB2B /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = 3AAF6E731A3CE4CB00C657FB;
+			remoteInfo = BuildaUtils;
+		};
 		3AAF6E891A3CE4CC00C657FB /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
 			containerPortal = 3A5687681A3B93BD0066DB2B /* Project object */;
@@ -152,6 +162,9 @@
 
 /* Begin PBXFileReference section */
 		3A1546451B02A0C6001EEB45 /* Script.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Script.swift; sourceTree = "<group>"; };
+		3A15464B1B02A32C001EEB45 /* BuildaUtilsTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = BuildaUtilsTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
+		3A15465A1B02A37D001EEB45 /* ScriptTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ScriptTests.swift; sourceTree = "<group>"; };
+		3A15465E1B02A4CE001EEB45 /* Info.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		3A2F9D811A8FE5D700B0DB68 /* StorageManager.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = StorageManager.swift; sourceTree = "<group>"; };
 		3A2F9D841A8FE64900B0DB68 /* LocalSource.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = LocalSource.swift; sourceTree = "<group>"; };
 		3A2F9D851A8FE64900B0DB68 /* Syncer.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Syncer.swift; sourceTree = "<group>"; };
@@ -229,6 +242,14 @@
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
+		3A1546481B02A32C001EEB45 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				3A1546511B02A32C001EEB45 /* BuildaUtils.framework in Frameworks */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 		3A56876D1A3B93BD0066DB2B /* Frameworks */ = {
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
@@ -273,6 +294,23 @@
 /* End PBXFrameworksBuildPhase section */
 
 /* Begin PBXGroup section */
+		3A15464C1B02A32C001EEB45 /* BuildaUtilsTests */ = {
+			isa = PBXGroup;
+			children = (
+				3A15465A1B02A37D001EEB45 /* ScriptTests.swift */,
+				3A15464D1B02A32C001EEB45 /* Supporting Files */,
+			);
+			path = BuildaUtilsTests;
+			sourceTree = "<group>";
+		};
+		3A15464D1B02A32C001EEB45 /* Supporting Files */ = {
+			isa = PBXGroup;
+			children = (
+				3A15465E1B02A4CE001EEB45 /* Info.plist */,
+			);
+			name = "Supporting Files";
+			sourceTree = "<group>";
+		};
 		3A2F9D831A8FE63B00B0DB68 /* Model */ = {
 			isa = PBXGroup;
 			children = (
@@ -294,6 +332,7 @@
 				3AAF6EE51A3CE5BA00C657FB /* BuildaGitServer */,
 				3AAF6EF41A3CE5BA00C657FB /* BuildaGitServerTests */,
 				3AAF6E751A3CE4CC00C657FB /* BuildaUtils */,
+				3A15464C1B02A32C001EEB45 /* BuildaUtilsTests */,
 				3A5687711A3B93BD0066DB2B /* Products */,
 			);
 			sourceTree = "<group>";
@@ -306,6 +345,7 @@
 				3AAF6EBE1A3CE57100C657FB /* BuildaCIServer.framework */,
 				3AAF6EE41A3CE5BA00C657FB /* BuildaGitServer.framework */,
 				3AAF6EEE1A3CE5BA00C657FB /* BuildaGitServerTests.xctest */,
+				3A15464B1B02A32C001EEB45 /* BuildaUtilsTests.xctest */,
 			);
 			name = Products;
 			sourceTree = "<group>";
@@ -538,6 +578,24 @@
 /* End PBXHeadersBuildPhase section */
 
 /* Begin PBXNativeTarget section */
+		3A15464A1B02A32C001EEB45 /* BuildaUtilsTests */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = 3A1546541B02A32C001EEB45 /* Build configuration list for PBXNativeTarget "BuildaUtilsTests" */;
+			buildPhases = (
+				3A1546471B02A32C001EEB45 /* Sources */,
+				3A1546481B02A32C001EEB45 /* Frameworks */,
+				3A1546491B02A32C001EEB45 /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+				3A1546531B02A32C001EEB45 /* PBXTargetDependency */,
+			);
+			name = BuildaUtilsTests;
+			productName = BuildaUtilsTests;
+			productReference = 3A15464B1B02A32C001EEB45 /* BuildaUtilsTests.xctest */;
+			productType = "com.apple.product-type.bundle.unit-test";
+		};
 		3A56876F1A3B93BD0066DB2B /* Buildasaur */ = {
 			isa = PBXNativeTarget;
 			buildConfigurationList = 3A56878C1A3B93BD0066DB2B /* Build configuration list for PBXNativeTarget "Buildasaur" */;
@@ -643,6 +701,9 @@
 				LastUpgradeCheck = 0610;
 				ORGANIZATIONNAME = "Honza Dvorsky";
 				TargetAttributes = {
+					3A15464A1B02A32C001EEB45 = {
+						CreatedOnToolsVersion = 6.3.1;
+					};
 					3A56876F1A3B93BD0066DB2B = {
 						CreatedOnToolsVersion = 6.1.1;
 						SystemCapabilities = {
@@ -684,11 +745,20 @@
 				3AAF6EBD1A3CE57100C657FB /* BuildaCIServer */,
 				3AAF6EE31A3CE5BA00C657FB /* BuildaGitServer */,
 				3AAF6EED1A3CE5BA00C657FB /* BuildaGitServerTests */,
+				3A15464A1B02A32C001EEB45 /* BuildaUtilsTests */,
 			);
 		};
 /* End PBXProject section */
 
 /* Begin PBXResourcesBuildPhase section */
+		3A1546491B02A32C001EEB45 /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				3A15465F1B02A4CE001EEB45 /* Info.plist in Resources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 		3A56876E1A3B93BD0066DB2B /* Resources */ = {
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
@@ -729,6 +799,14 @@
 /* End PBXResourcesBuildPhase section */
 
 /* Begin PBXSourcesBuildPhase section */
+		3A1546471B02A32C001EEB45 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				3A15465B1B02A37D001EEB45 /* ScriptTests.swift in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 		3A56876C1A3B93BD0066DB2B /* Sources */ = {
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
@@ -826,6 +904,11 @@
 /* End PBXSourcesBuildPhase section */
 
 /* Begin PBXTargetDependency section */
+		3A1546531B02A32C001EEB45 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = 3AAF6E731A3CE4CB00C657FB /* BuildaUtils */;
+			targetProxy = 3A1546521B02A32C001EEB45 /* PBXContainerItemProxy */;
+		};
 		3AAF6E8A1A3CE4CC00C657FB /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
 			target = 3AAF6E731A3CE4CB00C657FB /* BuildaUtils */;
@@ -875,6 +958,59 @@
 /* End PBXVariantGroup section */
 
 /* Begin XCBuildConfiguration section */
+		3A1546551B02A32C001EEB45 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				COMBINE_HIDPI_IMAGES = YES;
+				FRAMEWORK_SEARCH_PATHS = (
+					"$(DEVELOPER_FRAMEWORKS_DIR)",
+					"$(inherited)",
+				);
+				GCC_NO_COMMON_BLOCKS = YES;
+				GCC_PREPROCESSOR_DEFINITIONS = (
+					"DEBUG=1",
+					"$(inherited)",
+				);
+				INFOPLIST_FILE = BuildaUtilsTests/Info.plist;
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/../Frameworks @loader_path/../Frameworks";
+				PRODUCT_NAME = "$(TARGET_NAME)";
+			};
+			name = Debug;
+		};
+		3A1546561B02A32C001EEB45 /* Testing */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				COMBINE_HIDPI_IMAGES = YES;
+				COPY_PHASE_STRIP = NO;
+				ENABLE_NS_ASSERTIONS = NO;
+				FRAMEWORK_SEARCH_PATHS = (
+					"$(DEVELOPER_FRAMEWORKS_DIR)",
+					"$(inherited)",
+				);
+				GCC_NO_COMMON_BLOCKS = YES;
+				INFOPLIST_FILE = BuildaUtilsTests/Info.plist;
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/../Frameworks @loader_path/../Frameworks";
+				PRODUCT_NAME = "$(TARGET_NAME)";
+			};
+			name = Testing;
+		};
+		3A1546571B02A32C001EEB45 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				COMBINE_HIDPI_IMAGES = YES;
+				COPY_PHASE_STRIP = NO;
+				ENABLE_NS_ASSERTIONS = NO;
+				FRAMEWORK_SEARCH_PATHS = (
+					"$(DEVELOPER_FRAMEWORKS_DIR)",
+					"$(inherited)",
+				);
+				GCC_NO_COMMON_BLOCKS = YES;
+				INFOPLIST_FILE = BuildaUtilsTests/Info.plist;
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/../Frameworks @loader_path/../Frameworks";
+				PRODUCT_NAME = "$(TARGET_NAME)";
+			};
+			name = Release;
+		};
 		3A56878A1A3B93BD0066DB2B /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
@@ -1303,6 +1439,15 @@
 /* End XCBuildConfiguration section */
 
 /* Begin XCConfigurationList section */
+		3A1546541B02A32C001EEB45 /* Build configuration list for PBXNativeTarget "BuildaUtilsTests" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				3A1546551B02A32C001EEB45 /* Debug */,
+				3A1546561B02A32C001EEB45 /* Testing */,
+				3A1546571B02A32C001EEB45 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+		};
 		3A56876B1A3B93BD0066DB2B /* Build configuration list for PBXProject "Buildasaur" */ = {
 			isa = XCConfigurationList;
 			buildConfigurations = (

--- a/Buildasaur.xcodeproj/project.pbxproj
+++ b/Buildasaur.xcodeproj/project.pbxproj
@@ -7,6 +7,7 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		3A1546461B02A0C6001EEB45 /* Script.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3A1546451B02A0C6001EEB45 /* Script.swift */; };
 		3A2F9D821A8FE5D700B0DB68 /* StorageManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3A2F9D811A8FE5D700B0DB68 /* StorageManager.swift */; };
 		3A2F9D861A8FE64900B0DB68 /* LocalSource.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3A2F9D841A8FE64900B0DB68 /* LocalSource.swift */; };
 		3A2F9D871A8FE64900B0DB68 /* Syncer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3A2F9D851A8FE64900B0DB68 /* Syncer.swift */; };
@@ -150,6 +151,7 @@
 /* End PBXCopyFilesBuildPhase section */
 
 /* Begin PBXFileReference section */
+		3A1546451B02A0C6001EEB45 /* Script.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Script.swift; sourceTree = "<group>"; };
 		3A2F9D811A8FE5D700B0DB68 /* StorageManager.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = StorageManager.swift; sourceTree = "<group>"; };
 		3A2F9D841A8FE64900B0DB68 /* LocalSource.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = LocalSource.swift; sourceTree = "<group>"; };
 		3A2F9D851A8FE64900B0DB68 /* Syncer.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Syncer.swift; sourceTree = "<group>"; };
@@ -428,6 +430,7 @@
 				3AAF6E761A3CE4CC00C657FB /* Supporting Files */,
 				3AAA1B731AABBD3A00FA1598 /* Errors.swift */,
 				3A3BDC1C1AF6C51900D2CD99 /* Extensions.swift */,
+				3A1546451B02A0C6001EEB45 /* Script.swift */,
 			);
 			path = BuildaUtils;
 			sourceTree = "<group>";
@@ -766,6 +769,7 @@
 				3A808A1B1ADB03640073145D /* Logging.swift in Sources */,
 				3AF1B1221AAC621800917EF3 /* UIUtils.swift in Sources */,
 				3A4770A41A745FFA0016E170 /* XcodeProjectParser.swift in Sources */,
+				3A1546461B02A0C6001EEB45 /* Script.swift in Sources */,
 				3AAF6F0A1A3CE75600C657FB /* JSON.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/Buildasaur.xcodeproj/project.pbxproj
+++ b/Buildasaur.xcodeproj/project.pbxproj
@@ -10,7 +10,6 @@
 		3A1546461B02A0C6001EEB45 /* Script.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3A1546451B02A0C6001EEB45 /* Script.swift */; };
 		3A1546511B02A32C001EEB45 /* BuildaUtils.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 3AAF6E741A3CE4CC00C657FB /* BuildaUtils.framework */; };
 		3A15465B1B02A37D001EEB45 /* ScriptTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3A15465A1B02A37D001EEB45 /* ScriptTests.swift */; };
-		3A15465F1B02A4CE001EEB45 /* Info.plist in Resources */ = {isa = PBXBuildFile; fileRef = 3A15465E1B02A4CE001EEB45 /* Info.plist */; };
 		3A2F9D821A8FE5D700B0DB68 /* StorageManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3A2F9D811A8FE5D700B0DB68 /* StorageManager.swift */; };
 		3A2F9D861A8FE64900B0DB68 /* LocalSource.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3A2F9D841A8FE64900B0DB68 /* LocalSource.swift */; };
 		3A2F9D871A8FE64900B0DB68 /* Syncer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3A2F9D851A8FE64900B0DB68 /* Syncer.swift */; };
@@ -83,6 +82,7 @@
 		3AD338B01AAE31D500ECD0F2 /* BuildTemplateViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3AD338AF1AAE31D500ECD0F2 /* BuildTemplateViewController.swift */; };
 		3AF1B1221AAC621800917EF3 /* UIUtils.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3AF1B1211AAC621800917EF3 /* UIUtils.swift */; };
 		3AF1B1241AAC7CA500917EF3 /* StatusSyncerViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3AF1B1231AAC7CA500917EF3 /* StatusSyncerViewController.swift */; };
+		3AF2B03B1B02C5D700DCF2D6 /* SSHKeyVerification.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3AF2B03A1B02C5D700DCF2D6 /* SSHKeyVerification.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -239,6 +239,7 @@
 		3AD338AF1AAE31D500ECD0F2 /* BuildTemplateViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = BuildTemplateViewController.swift; sourceTree = "<group>"; };
 		3AF1B1211AAC621800917EF3 /* UIUtils.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = UIUtils.swift; sourceTree = "<group>"; };
 		3AF1B1231AAC7CA500917EF3 /* StatusSyncerViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = StatusSyncerViewController.swift; sourceTree = "<group>"; };
+		3AF2B03A1B02C5D700DCF2D6 /* SSHKeyVerification.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SSHKeyVerification.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -471,6 +472,7 @@
 				3AAA1B731AABBD3A00FA1598 /* Errors.swift */,
 				3A3BDC1C1AF6C51900D2CD99 /* Extensions.swift */,
 				3A1546451B02A0C6001EEB45 /* Script.swift */,
+				3AF2B03A1B02C5D700DCF2D6 /* SSHKeyVerification.swift */,
 			);
 			path = BuildaUtils;
 			sourceTree = "<group>";
@@ -755,7 +757,6 @@
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				3A15465F1B02A4CE001EEB45 /* Info.plist in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -848,6 +849,7 @@
 				3AF1B1221AAC621800917EF3 /* UIUtils.swift in Sources */,
 				3A4770A41A745FFA0016E170 /* XcodeProjectParser.swift in Sources */,
 				3A1546461B02A0C6001EEB45 /* Script.swift in Sources */,
+				3AF2B03B1B02C5D700DCF2D6 /* SSHKeyVerification.swift in Sources */,
 				3AAF6F0A1A3CE75600C657FB /* JSON.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -1447,6 +1449,7 @@
 				3A1546571B02A32C001EEB45 /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
 		};
 		3A56876B1A3B93BD0066DB2B /* Build configuration list for PBXProject "Buildasaur" */ = {
 			isa = XCConfigurationList;

--- a/Buildasaur.xcodeproj/xcshareddata/xcschemes/BuildaGitServerTests.xcscheme
+++ b/Buildasaur.xcodeproj/xcshareddata/xcschemes/BuildaGitServerTests.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "0610"
+   LastUpgradeVersion = "0630"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"
@@ -9,14 +9,14 @@
          <BuildActionEntry
             buildForTesting = "YES"
             buildForRunning = "YES"
-            buildForProfiling = "YES"
-            buildForArchiving = "YES"
+            buildForProfiling = "NO"
+            buildForArchiving = "NO"
             buildForAnalyzing = "YES">
             <BuildableReference
                BuildableIdentifier = "primary"
-               BlueprintIdentifier = "3AAF6EE31A3CE5BA00C657FB"
-               BuildableName = "BuildaGitServer.framework"
-               BlueprintName = "BuildaGitServer"
+               BlueprintIdentifier = "3AAF6EED1A3CE5BA00C657FB"
+               BuildableName = "BuildaGitServerTests.xctest"
+               BlueprintName = "BuildaGitServerTests"
                ReferencedContainer = "container:Buildasaur.xcodeproj">
             </BuildableReference>
          </BuildActionEntry>
@@ -28,7 +28,26 @@
       shouldUseLaunchSchemeArgsEnv = "YES"
       buildConfiguration = "Debug">
       <Testables>
+         <TestableReference
+            skipped = "NO">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "3AAF6EED1A3CE5BA00C657FB"
+               BuildableName = "BuildaGitServerTests.xctest"
+               BlueprintName = "BuildaGitServerTests"
+               ReferencedContainer = "container:Buildasaur.xcodeproj">
+            </BuildableReference>
+         </TestableReference>
       </Testables>
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "3AAF6EED1A3CE5BA00C657FB"
+            BuildableName = "BuildaGitServerTests.xctest"
+            BlueprintName = "BuildaGitServerTests"
+            ReferencedContainer = "container:Buildasaur.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
    </TestAction>
    <LaunchAction
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
@@ -42,9 +61,9 @@
       <MacroExpansion>
          <BuildableReference
             BuildableIdentifier = "primary"
-            BlueprintIdentifier = "3AAF6EE31A3CE5BA00C657FB"
-            BuildableName = "BuildaGitServer.framework"
-            BlueprintName = "BuildaGitServer"
+            BlueprintIdentifier = "3AAF6EED1A3CE5BA00C657FB"
+            BuildableName = "BuildaGitServerTests.xctest"
+            BlueprintName = "BuildaGitServerTests"
             ReferencedContainer = "container:Buildasaur.xcodeproj">
          </BuildableReference>
       </MacroExpansion>
@@ -60,9 +79,9 @@
       <MacroExpansion>
          <BuildableReference
             BuildableIdentifier = "primary"
-            BlueprintIdentifier = "3AAF6EE31A3CE5BA00C657FB"
-            BuildableName = "BuildaGitServer.framework"
-            BlueprintName = "BuildaGitServer"
+            BlueprintIdentifier = "3AAF6EED1A3CE5BA00C657FB"
+            BuildableName = "BuildaGitServerTests.xctest"
+            BlueprintName = "BuildaGitServerTests"
             ReferencedContainer = "container:Buildasaur.xcodeproj">
          </BuildableReference>
       </MacroExpansion>

--- a/Buildasaur.xcodeproj/xcshareddata/xcschemes/BuildaUtilsTests.xcscheme
+++ b/Buildasaur.xcodeproj/xcshareddata/xcschemes/BuildaUtilsTests.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "0610"
+   LastUpgradeVersion = "0630"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"
@@ -9,14 +9,14 @@
          <BuildActionEntry
             buildForTesting = "YES"
             buildForRunning = "YES"
-            buildForProfiling = "YES"
-            buildForArchiving = "YES"
+            buildForProfiling = "NO"
+            buildForArchiving = "NO"
             buildForAnalyzing = "YES">
             <BuildableReference
                BuildableIdentifier = "primary"
-               BlueprintIdentifier = "3AAF6E991A3CE54800C657FB"
-               BuildableName = "CIServer.framework"
-               BlueprintName = "CIServer"
+               BlueprintIdentifier = "3A15464A1B02A32C001EEB45"
+               BuildableName = "BuildaUtilsTests.xctest"
+               BlueprintName = "BuildaUtilsTests"
                ReferencedContainer = "container:Buildasaur.xcodeproj">
             </BuildableReference>
          </BuildActionEntry>
@@ -28,7 +28,26 @@
       shouldUseLaunchSchemeArgsEnv = "YES"
       buildConfiguration = "Debug">
       <Testables>
+         <TestableReference
+            skipped = "NO">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "3A15464A1B02A32C001EEB45"
+               BuildableName = "BuildaUtilsTests.xctest"
+               BlueprintName = "BuildaUtilsTests"
+               ReferencedContainer = "container:Buildasaur.xcodeproj">
+            </BuildableReference>
+         </TestableReference>
       </Testables>
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "3A15464A1B02A32C001EEB45"
+            BuildableName = "BuildaUtilsTests.xctest"
+            BlueprintName = "BuildaUtilsTests"
+            ReferencedContainer = "container:Buildasaur.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
    </TestAction>
    <LaunchAction
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
@@ -42,9 +61,9 @@
       <MacroExpansion>
          <BuildableReference
             BuildableIdentifier = "primary"
-            BlueprintIdentifier = "3AAF6E991A3CE54800C657FB"
-            BuildableName = "CIServer.framework"
-            BlueprintName = "CIServer"
+            BlueprintIdentifier = "3A15464A1B02A32C001EEB45"
+            BuildableName = "BuildaUtilsTests.xctest"
+            BlueprintName = "BuildaUtilsTests"
             ReferencedContainer = "container:Buildasaur.xcodeproj">
          </BuildableReference>
       </MacroExpansion>
@@ -60,9 +79,9 @@
       <MacroExpansion>
          <BuildableReference
             BuildableIdentifier = "primary"
-            BlueprintIdentifier = "3AAF6E991A3CE54800C657FB"
-            BuildableName = "CIServer.framework"
-            BlueprintName = "CIServer"
+            BlueprintIdentifier = "3A15464A1B02A32C001EEB45"
+            BuildableName = "BuildaUtilsTests.xctest"
+            BlueprintName = "BuildaUtilsTests"
             ReferencedContainer = "container:Buildasaur.xcodeproj">
          </BuildableReference>
       </MacroExpansion>

--- a/Buildasaur/NetworkUtils.swift
+++ b/Buildasaur/NetworkUtils.swift
@@ -43,8 +43,7 @@ class NetworkUtils {
                         completion(success: false, error: Errors.errorWithInfo("Missing write permission for repo"))
                     } else {
                         //now test ssh keys
-                        //TODO: pass in the
-                        self.checkValidityOfSSHKeys(sshKeyPath, completion: { (success, error) -> () in
+                        self.checkValidityOfSSHKeys(sshKeyPath, repoSSHUrl: repo.repoUrlSSH, completion: { (success, error) -> () in
                             
                             //now complete
                             completion(success: success, error: error)
@@ -86,19 +85,17 @@ class NetworkUtils {
     }
     
     //TODO: take the path to the private key probs
-    class func checkValidityOfSSHKeys(path: String, completion: (success: Bool, error: NSError?) -> ()) {
+    class func checkValidityOfSSHKeys(path: String, repoSSHUrl: String, completion: (success: Bool, error: NSError?) -> ()) {
         
-        //create the validation bash script to run in temp folder
         //something like GIT_SSH_COMMAND='ssh -i /path/to/keys' git ls-remote git@github.com:owner/repo.git
-        //also wrap in logic for returning just success/error codes instead of full output
+        let r = Script.run("git", arguments: ["ls-remote", repoSSHUrl], environment: [
+            "GIT_SSH_COMMAND": "'ssh -i \(path)'"])
         
-        //run it
-        
-        //depending on the return value, either succeed or fail
-        
-        //delete the script
-        
-        assertionFailure("not yet implemented")
-        completion(success: false, error: Errors.errorWithInfo("Not implemented yet"))
+        //based on the return value, either succeed or fail
+        if r.terminationStatus == 0 {
+            completion(success: true, error: nil)
+        } else {
+            completion(success: false, error: Errors.errorWithInfo(r.standardError))
+        }
     }
 }

--- a/Buildasaur/NetworkUtils.swift
+++ b/Buildasaur/NetworkUtils.swift
@@ -17,6 +17,7 @@ class NetworkUtils {
         
         let token = project.githubToken
         let server = GitHubFactory.server(token)
+        let sshKeyPath = project.privateSSHKeyUrl?.path ?? ""
         
         //check if we can get PRs, that should be representative enough
         if let repoName = project.githubRepoName() {
@@ -41,7 +42,13 @@ class NetworkUtils {
                     } else if !writePermission {
                         completion(success: false, error: Errors.errorWithInfo("Missing write permission for repo"))
                     } else {
-                        completion(success: true, error: nil)
+                        //now test ssh keys
+                        //TODO: pass in the
+                        self.checkValidityOfSSHKeys(sshKeyPath, completion: { (success, error) -> () in
+                            
+                            //now complete
+                            completion(success: success, error: error)
+                        })
                     }
                 } else {
                     completion(success: false, error: Errors.errorWithInfo("Couldn't find repo permissions in GitHub response"))
@@ -76,5 +83,22 @@ class NetworkUtils {
                 completion(success: canCreateBots, error: nil)
             })
         }
+    }
+    
+    //TODO: take the path to the private key probs
+    class func checkValidityOfSSHKeys(path: String, completion: (success: Bool, error: NSError?) -> ()) {
+        
+        //create the validation bash script to run in temp folder
+        //something like GIT_SSH_COMMAND='ssh -i /path/to/keys' git ls-remote git@github.com:owner/repo.git
+        //also wrap in logic for returning just success/error codes instead of full output
+        
+        //run it
+        
+        //depending on the return value, either succeed or fail
+        
+        //delete the script
+        
+        assertionFailure("not yet implemented")
+        completion(success: false, error: Errors.errorWithInfo("Not implemented yet"))
     }
 }

--- a/Buildasaur/NetworkUtils.swift
+++ b/Buildasaur/NetworkUtils.swift
@@ -87,20 +87,7 @@ class NetworkUtils {
     //TODO: take the path to the private key probs
     class func checkValidityOfSSHKeys(path: String, repoSSHUrl: String, completion: (success: Bool, error: NSError?) -> ()) {
         
-        //create a temp script, because NSTask is being difficult and doesn't play nice with environment variables,
-        //which we need for forcing SSH keys from a specific path to verify they are valid for your repo. sigh.
-        let uuid = NSUUID().UUIDString
-        let tempPath = NSTemporaryDirectory().stringByAppendingPathComponent(uuid)
-        let script = "GIT_SSH_COMMAND='ssh -i \(path)' git ls-remote \(repoSSHUrl)\n"
-        
-        var error: NSError?
-        let success = script.writeToFile(tempPath, atomically: true, encoding: NSUTF8StringEncoding, error: &error)
-        
-        //something like GIT_SSH_COMMAND='ssh -i /path/to/keys' git ls-remote git@github.com:owner/repo.git
-        let r = Script.run("bash", arguments: [tempPath])
-        
-        //delete the temp script
-        NSFileManager.defaultManager().removeItemAtPath(tempPath, error: nil)
+        let r = SSHKeyVerification.verifyKeys(path, repoSSHUrl: repoSSHUrl)
         
         //based on the return value, either succeed or fail
         if r.terminationStatus == 0 {

--- a/Buildasaur/NetworkUtils.swift
+++ b/Buildasaur/NetworkUtils.swift
@@ -44,7 +44,7 @@ class NetworkUtils {
                     } else {
                         //now test ssh keys
                         self.checkValidityOfSSHKeys(sshKeyPath, repoSSHUrl: repo.repoUrlSSH, completion: { (success, error) -> () in
-                            
+                        
                             //now complete
                             completion(success: success, error: error)
                         })
@@ -87,9 +87,20 @@ class NetworkUtils {
     //TODO: take the path to the private key probs
     class func checkValidityOfSSHKeys(path: String, repoSSHUrl: String, completion: (success: Bool, error: NSError?) -> ()) {
         
+        //create a temp script, because NSTask is being difficult and doesn't play nice with environment variables,
+        //which we need for forcing SSH keys from a specific path to verify they are valid for your repo. sigh.
+        let uuid = NSUUID().UUIDString
+        let tempPath = NSTemporaryDirectory().stringByAppendingPathComponent(uuid)
+        let script = "GIT_SSH_COMMAND='ssh -i \(path)' git ls-remote \(repoSSHUrl)\n"
+        
+        var error: NSError?
+        let success = script.writeToFile(tempPath, atomically: true, encoding: NSUTF8StringEncoding, error: &error)
+        
         //something like GIT_SSH_COMMAND='ssh -i /path/to/keys' git ls-remote git@github.com:owner/repo.git
-        let r = Script.run("git", arguments: ["ls-remote", repoSSHUrl], environment: [
-            "GIT_SSH_COMMAND": "'ssh -i \(path)'"])
+        let r = Script.run("bash", arguments: [tempPath])
+        
+        //delete the temp script
+        NSFileManager.defaultManager().removeItemAtPath(tempPath, error: nil)
         
         //based on the return value, either succeed or fail
         if r.terminationStatus == 0 {


### PR DESCRIPTION
Fixes #30. Now SSH keys are validated that they have access to the specified repo. Uses a temp script that forces ssh keys and tries to call `git ls-remote` from the remote. Should help catch SSH key issues early.

Thanks, @accatyyc for help with this one!
