### PR TITLE
Add a build status badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,30 @@
 Buildasaur
 ==========
 
+<a id="user-content-buildaLink" href="https://github.com/czechboy0/Buildasaur/commits/master"></a>
+<script src="http://code.jquery.com/jquery-1.11.3.js"></script>
+<script type="text/javascript">
+$.ajax({
+url: "https://api.github.com/repos/czechboy0/buildasaur/commits/master/status",
+data: "",
+success: function(data, textStatus, something) {
+var status = data['state'];
+var imgPath = 'https://img.shields.io/badge/';
+if (status === 'success') {
+  imgPath = imgPath + 'build-passing-green.svg';
+} else if (status === 'failure') {
+  imgPath = imgPath + 'build-failing-red.svg';
+} else { 
+  imgPath = imgPath + 'build-unknown-gray.svg';
+}
+$('<img src="'+ imgPath +'">').load(function() {
+  $(this).width(90).height(20).appendTo('#user-content-buildaLink');
+});
+},
+dataType: "json"
+})
+</script>
+
 [![Blog](https://img.shields.io/badge/blog-honzadvorsky.com-green.svg)](http://honzadvorsky.com)
 [![Twitter Buildasaur](https://img.shields.io/badge/twitter-Buildasaur-green.svg)](http://twitter.com/buildasaur)
 [![Twitter Czechboy0](https://img.shields.io/badge/twitter-czechboy0-green.svg)](http://twitter.com/czechboy0)

--- a/README.md
+++ b/README.md
@@ -2,15 +2,15 @@ Buildasaur
 ==========
 
 [![Build Status](http://178.62.79.155/buildasaur)](https://github.com/czechboy0/Buildasaur/commits/master)
-[![Blog](https://img.shields.io/badge/blog-honzadvorsky.com-green.svg)](http://honzadvorsky.com)
-[![Twitter Buildasaur](https://img.shields.io/badge/twitter-Buildasaur-green.svg)](http://twitter.com/buildasaur)
-[![Twitter Czechboy0](https://img.shields.io/badge/twitter-czechboy0-green.svg)](http://twitter.com/czechboy0)
-
 [![Stars](https://img.shields.io/github/stars/czechboy0/buildasaur.svg)](https://github.com/czechboy0/Buildasaur/stargazers)
 [![Forks](https://img.shields.io/github/forks/czechboy0/buildasaur.svg)](https://github.com/czechboy0/Buildasaur/network/members)
 [![Issues](https://img.shields.io/github/issues-raw/czechboy0/buildasaur.svg)](https://github.com/czechboy0/Buildasaur/issues)
-[![License](https://img.shields.io/badge/license-MIT-blue.svg)](http://en.wikipedia.org/wiki/MIT_License)
 [![Latest Buildasaur Release](https://img.shields.io/github/release/czechboy0/buildasaur.svg)](https://github.com/czechboy0/Buildasaur/releases/latest)
+
+[![License](https://img.shields.io/badge/license-MIT-blue.svg)](http://en.wikipedia.org/wiki/MIT_License)
+[![Blog](https://img.shields.io/badge/blog-honzadvorsky.com-green.svg)](http://honzadvorsky.com)
+[![Twitter Buildasaur](https://img.shields.io/badge/twitter-Buildasaur-green.svg)](http://twitter.com/buildasaur)
+[![Twitter Czechboy0](https://img.shields.io/badge/twitter-czechboy0-green.svg)](http://twitter.com/czechboy0)
 
 ![](https://raw.githubusercontent.com/czechboy0/Buildasaur/master/Buildasaur/Images.xcassets/AppIcon.appiconset/builda_icon%40128x.png)
 

--- a/README.md
+++ b/README.md
@@ -1,32 +1,7 @@
 Buildasaur
 ==========
 
-<dl>
-<a id="user-content-buildaLink" href="https://github.com/czechboy0/Buildasaur/commits/master">test</a>
-<script src="http://code.jquery.com/jquery-1.11.3.js"></script>
-<script type="text/javascript">
-$.ajax({
-url: "https://api.github.com/repos/czechboy0/buildasaur/commits/master/status",
-data: "",
-success: function(data, textStatus, something) {
-var status = data['state'];
-var imgPath = 'https://img.shields.io/badge/';
-if (status === 'success') {
-  imgPath = imgPath + 'build-passing-green.svg';
-} else if (status === 'failure') {
-  imgPath = imgPath + 'build-failing-red.svg';
-} else { 
-  imgPath = imgPath + 'build-unknown-gray.svg';
-}
-$('<img src="'+ imgPath +'">').load(function() {
-  $(this).width(90).height(20).appendTo('#user-content-buildaLink');
-});
-},
-dataType: "json"
-})
-</script>
-</dl>
-
+[![Build Status](http://178.62.79.155/buildasaur)](https://github.com/czechboy0/Buildasaur/commits/master)
 [![Blog](https://img.shields.io/badge/blog-honzadvorsky.com-green.svg)](http://honzadvorsky.com)
 [![Twitter Buildasaur](https://img.shields.io/badge/twitter-Buildasaur-green.svg)](http://twitter.com/buildasaur)
 [![Twitter Czechboy0](https://img.shields.io/badge/twitter-czechboy0-green.svg)](http://twitter.com/czechboy0)

--- a/README.md
+++ b/README.md
@@ -1,7 +1,8 @@
 Buildasaur
 ==========
 
-<a id="user-content-buildaLink" href="https://github.com/czechboy0/Buildasaur/commits/master"></a>
+<dl>
+<a id="user-content-buildaLink" href="https://github.com/czechboy0/Buildasaur/commits/master">test</a>
 <script src="http://code.jquery.com/jquery-1.11.3.js"></script>
 <script type="text/javascript">
 $.ajax({
@@ -24,6 +25,7 @@ $('<img src="'+ imgPath +'">').load(function() {
 dataType: "json"
 })
 </script>
+</dl>
 
 [![Blog](https://img.shields.io/badge/blog-honzadvorsky.com-green.svg)](http://honzadvorsky.com)
 [![Twitter Buildasaur](https://img.shields.io/badge/twitter-Buildasaur-green.svg)](http://twitter.com/buildasaur)


### PR DESCRIPTION
I define "build status" of Buildasaur to be derived from the last commit on master. Can be "unknown", "failing", and (hopefully always) "success". At the moment I use my playground server for doing the back and forth, unfortunately my client-side, jQuery version didn't work in GitHub's markdown :( 

Fixes #33, but before can be really useful, we need #18 to be done.
