### PR TITLE
Adding Branch Watching

### DIFF
--- a/Buildasaur.xcodeproj/project.pbxproj
+++ b/Buildasaur.xcodeproj/project.pbxproj
@@ -9,6 +9,10 @@
 /* Begin PBXBuildFile section */
 		3A0BC03F1B0BD9C10020AB9F /* SyncPair_Branch_Bot.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3A0BC03E1B0BD9C10020AB9F /* SyncPair_Branch_Bot.swift */; };
 		3A0BC0411B0BDA530020AB9F /* SyncPairExtensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3A0BC0401B0BDA530020AB9F /* SyncPairExtensions.swift */; };
+		3A0BC0431B0BEF410020AB9F /* SyncPairResolver.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3A0BC0421B0BEF410020AB9F /* SyncPairResolver.swift */; };
+		3A0BC0451B0BF5A20020AB9F /* SyncPairPRResolver.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3A0BC0441B0BF5A20020AB9F /* SyncPairPRResolver.swift */; };
+		3A0BC0471B0BF5B20020AB9F /* SyncPairBranchResolver.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3A0BC0461B0BF5B20020AB9F /* SyncPairBranchResolver.swift */; };
+		3A0BC0491B0BFB5D0020AB9F /* SyncPair_Branch_NoBot.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3A0BC0481B0BFB5D0020AB9F /* SyncPair_Branch_NoBot.swift */; };
 		3A1546461B02A0C6001EEB45 /* Script.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3A1546451B02A0C6001EEB45 /* Script.swift */; };
 		3A1546511B02A32C001EEB45 /* BuildaUtils.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 3AAF6E741A3CE4CC00C657FB /* BuildaUtils.framework */; };
 		3A15465B1B02A37D001EEB45 /* ScriptTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3A15465A1B02A37D001EEB45 /* ScriptTests.swift */; };
@@ -28,7 +32,7 @@
 		3A46A2CA1B07E28700F0FA4B /* SyncPair.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3A46A2C91B07E28700F0FA4B /* SyncPair.swift */; };
 		3A46A2CD1B07E38E00F0FA4B /* SyncPair_PR_NoBot.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3A46A2CC1B07E38E00F0FA4B /* SyncPair_PR_NoBot.swift */; };
 		3A46A2CF1B07E60200F0FA4B /* SyncPair_PR_Bot.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3A46A2CE1B07E60200F0FA4B /* SyncPair_PR_Bot.swift */; };
-		3A46A2D11B07E64F00F0FA4B /* SyncPair_NoPR_Bot.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3A46A2D01B07E64F00F0FA4B /* SyncPair_NoPR_Bot.swift */; };
+		3A46A2D11B07E64F00F0FA4B /* SyncPair_Deletable_Bot.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3A46A2D01B07E64F00F0FA4B /* SyncPair_Deletable_Bot.swift */; };
 		3A46A2E31B081F2100F0FA4B /* SyncerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3A46A2E21B081F2100F0FA4B /* SyncerTests.swift */; };
 		3A4770A21A745F470016E170 /* StorageUtils.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3A4770A11A745F470016E170 /* StorageUtils.swift */; };
 		3A4770A41A745FFA0016E170 /* XcodeProjectParser.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3A4770A31A745FFA0016E170 /* XcodeProjectParser.swift */; };
@@ -187,6 +191,10 @@
 /* Begin PBXFileReference section */
 		3A0BC03E1B0BD9C10020AB9F /* SyncPair_Branch_Bot.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SyncPair_Branch_Bot.swift; sourceTree = "<group>"; };
 		3A0BC0401B0BDA530020AB9F /* SyncPairExtensions.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SyncPairExtensions.swift; sourceTree = "<group>"; };
+		3A0BC0421B0BEF410020AB9F /* SyncPairResolver.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SyncPairResolver.swift; sourceTree = "<group>"; };
+		3A0BC0441B0BF5A20020AB9F /* SyncPairPRResolver.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SyncPairPRResolver.swift; sourceTree = "<group>"; };
+		3A0BC0461B0BF5B20020AB9F /* SyncPairBranchResolver.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SyncPairBranchResolver.swift; sourceTree = "<group>"; };
+		3A0BC0481B0BFB5D0020AB9F /* SyncPair_Branch_NoBot.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SyncPair_Branch_NoBot.swift; sourceTree = "<group>"; };
 		3A1546451B02A0C6001EEB45 /* Script.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Script.swift; sourceTree = "<group>"; };
 		3A15464B1B02A32C001EEB45 /* BuildaUtilsTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = BuildaUtilsTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		3A15465A1B02A37D001EEB45 /* ScriptTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ScriptTests.swift; sourceTree = "<group>"; };
@@ -208,7 +216,7 @@
 		3A46A2C91B07E28700F0FA4B /* SyncPair.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SyncPair.swift; sourceTree = "<group>"; };
 		3A46A2CC1B07E38E00F0FA4B /* SyncPair_PR_NoBot.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SyncPair_PR_NoBot.swift; sourceTree = "<group>"; };
 		3A46A2CE1B07E60200F0FA4B /* SyncPair_PR_Bot.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SyncPair_PR_Bot.swift; sourceTree = "<group>"; };
-		3A46A2D01B07E64F00F0FA4B /* SyncPair_NoPR_Bot.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SyncPair_NoPR_Bot.swift; sourceTree = "<group>"; };
+		3A46A2D01B07E64F00F0FA4B /* SyncPair_Deletable_Bot.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SyncPair_Deletable_Bot.swift; sourceTree = "<group>"; };
 		3A46A2D61B081EF400F0FA4B /* BuildasaurTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = BuildasaurTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		3A46A2D91B081EF400F0FA4B /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		3A46A2E21B081F2100F0FA4B /* SyncerTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SyncerTests.swift; sourceTree = "<group>"; };
@@ -395,8 +403,12 @@
 				3A0BC0401B0BDA530020AB9F /* SyncPairExtensions.swift */,
 				3A46A2CC1B07E38E00F0FA4B /* SyncPair_PR_NoBot.swift */,
 				3A46A2CE1B07E60200F0FA4B /* SyncPair_PR_Bot.swift */,
-				3A46A2D01B07E64F00F0FA4B /* SyncPair_NoPR_Bot.swift */,
+				3A46A2D01B07E64F00F0FA4B /* SyncPair_Deletable_Bot.swift */,
+				3A0BC0481B0BFB5D0020AB9F /* SyncPair_Branch_NoBot.swift */,
 				3A0BC03E1B0BD9C10020AB9F /* SyncPair_Branch_Bot.swift */,
+				3A0BC0421B0BEF410020AB9F /* SyncPairResolver.swift */,
+				3A0BC0441B0BF5A20020AB9F /* SyncPairPRResolver.swift */,
+				3A0BC0461B0BF5B20020AB9F /* SyncPairBranchResolver.swift */,
 			);
 			name = SyncPairs;
 			sourceTree = "<group>";
@@ -956,6 +968,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				3A0BC0431B0BEF410020AB9F /* SyncPairResolver.swift in Sources */,
 				3AAA1B761AAC504700FA1598 /* StatusServerViewController.swift in Sources */,
 				3A46A2C81B07DF8F00F0FA4B /* SyncerBotUtils.swift in Sources */,
 				3A46A2C61B07DEAE00F0FA4B /* SyncerGitHubUtils.swift in Sources */,
@@ -964,6 +977,7 @@
 				3A46A2CA1B07E28700F0FA4B /* SyncPair.swift in Sources */,
 				3A2F9D861A8FE64900B0DB68 /* LocalSource.swift in Sources */,
 				3A46A2C11B07D8D800F0FA4B /* SyncerBotNaming.swift in Sources */,
+				3A0BC0491B0BFB5D0020AB9F /* SyncPair_Branch_NoBot.swift in Sources */,
 				3A46A2C31B07DCCA00F0FA4B /* SyncerBotManipulation.swift in Sources */,
 				3A5B04AC1AB4AC0F00F60536 /* SetupViewController.swift in Sources */,
 				3A5B04AA1AB4ABEB00F60536 /* TriggerViewController.swift in Sources */,
@@ -977,6 +991,7 @@
 				3AAA1B781AAC508A00FA1598 /* StatusViewController.swift in Sources */,
 				3A4770A21A745F470016E170 /* StorageUtils.swift in Sources */,
 				3A0BC03F1B0BD9C10020AB9F /* SyncPair_Branch_Bot.swift in Sources */,
+				3A0BC0471B0BF5B20020AB9F /* SyncPairBranchResolver.swift in Sources */,
 				3AAA1B721AABBBB200FA1598 /* NetworkUtils.swift in Sources */,
 				3AAA1B661AAB6E9800FA1598 /* SeparatorView.swift in Sources */,
 				3A2F9D871A8FE64900B0DB68 /* Syncer.swift in Sources */,
@@ -985,7 +1000,8 @@
 				3A331C411A940C8D0005AA98 /* CommonExtensions.swift in Sources */,
 				3AD338B01AAE31D500ECD0F2 /* BuildTemplateViewController.swift in Sources */,
 				3A90C4C01A90220F0048C040 /* HDGitHubXCBotSyncer.swift in Sources */,
-				3A46A2D11B07E64F00F0FA4B /* SyncPair_NoPR_Bot.swift in Sources */,
+				3A0BC0451B0BF5A20020AB9F /* SyncPairPRResolver.swift in Sources */,
+				3A46A2D11B07E64F00F0FA4B /* SyncPair_Deletable_Bot.swift in Sources */,
 				3AAA1B681AAB722600FA1598 /* StatusProjectViewController.swift in Sources */,
 				3AB3FDCB1B05644300021197 /* MenuItemManager.swift in Sources */,
 			);

--- a/Buildasaur.xcodeproj/project.pbxproj
+++ b/Buildasaur.xcodeproj/project.pbxproj
@@ -7,6 +7,8 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		3A0BC03F1B0BD9C10020AB9F /* SyncPair_Branch_Bot.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3A0BC03E1B0BD9C10020AB9F /* SyncPair_Branch_Bot.swift */; };
+		3A0BC0411B0BDA530020AB9F /* SyncPairExtensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3A0BC0401B0BDA530020AB9F /* SyncPairExtensions.swift */; };
 		3A1546461B02A0C6001EEB45 /* Script.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3A1546451B02A0C6001EEB45 /* Script.swift */; };
 		3A1546511B02A32C001EEB45 /* BuildaUtils.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 3AAF6E741A3CE4CC00C657FB /* BuildaUtils.framework */; };
 		3A15465B1B02A37D001EEB45 /* ScriptTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3A15465A1B02A37D001EEB45 /* ScriptTests.swift */; };
@@ -183,6 +185,8 @@
 /* End PBXCopyFilesBuildPhase section */
 
 /* Begin PBXFileReference section */
+		3A0BC03E1B0BD9C10020AB9F /* SyncPair_Branch_Bot.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SyncPair_Branch_Bot.swift; sourceTree = "<group>"; };
+		3A0BC0401B0BDA530020AB9F /* SyncPairExtensions.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SyncPairExtensions.swift; sourceTree = "<group>"; };
 		3A1546451B02A0C6001EEB45 /* Script.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Script.swift; sourceTree = "<group>"; };
 		3A15464B1B02A32C001EEB45 /* BuildaUtilsTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = BuildaUtilsTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		3A15465A1B02A37D001EEB45 /* ScriptTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ScriptTests.swift; sourceTree = "<group>"; };
@@ -388,9 +392,11 @@
 			isa = PBXGroup;
 			children = (
 				3A46A2C91B07E28700F0FA4B /* SyncPair.swift */,
+				3A0BC0401B0BDA530020AB9F /* SyncPairExtensions.swift */,
 				3A46A2CC1B07E38E00F0FA4B /* SyncPair_PR_NoBot.swift */,
 				3A46A2CE1B07E60200F0FA4B /* SyncPair_PR_Bot.swift */,
 				3A46A2D01B07E64F00F0FA4B /* SyncPair_NoPR_Bot.swift */,
+				3A0BC03E1B0BD9C10020AB9F /* SyncPair_Branch_Bot.swift */,
 			);
 			name = SyncPairs;
 			sourceTree = "<group>";
@@ -962,6 +968,7 @@
 				3A5B04AC1AB4AC0F00F60536 /* SetupViewController.swift in Sources */,
 				3A5B04AA1AB4ABEB00F60536 /* TriggerViewController.swift in Sources */,
 				3AF1B1241AAC7CA500917EF3 /* StatusSyncerViewController.swift in Sources */,
+				3A0BC0411B0BDA530020AB9F /* SyncPairExtensions.swift in Sources */,
 				3A5B04B21AB5C42A00F60536 /* XcodeServerSyncerUtils.swift in Sources */,
 				3A46A2CD1B07E38E00F0FA4B /* SyncPair_PR_NoBot.swift in Sources */,
 				3A5B04B01AB5144700F60536 /* ManualBotManagementViewController.swift in Sources */,
@@ -969,6 +976,7 @@
 				3A2F9D821A8FE5D700B0DB68 /* StorageManager.swift in Sources */,
 				3AAA1B781AAC508A00FA1598 /* StatusViewController.swift in Sources */,
 				3A4770A21A745F470016E170 /* StorageUtils.swift in Sources */,
+				3A0BC03F1B0BD9C10020AB9F /* SyncPair_Branch_Bot.swift in Sources */,
 				3AAA1B721AABBBB200FA1598 /* NetworkUtils.swift in Sources */,
 				3AAA1B661AAB6E9800FA1598 /* SeparatorView.swift in Sources */,
 				3A2F9D871A8FE64900B0DB68 /* Syncer.swift in Sources */,

--- a/Buildasaur.xcodeproj/project.pbxproj
+++ b/Buildasaur.xcodeproj/project.pbxproj
@@ -101,6 +101,7 @@
 		3AB489901B0929F8005C87BE /* sampleFinishedIntegration.json in Resources */ = {isa = PBXBuildFile; fileRef = 3AB4898F1B0929F8005C87BE /* sampleFinishedIntegration.json */; };
 		3AC553AF1A6313240078CCA6 /* XcodeServerConstants.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3AC553AE1A6313240078CCA6 /* XcodeServerConstants.swift */; };
 		3AD338B01AAE31D500ECD0F2 /* BuildTemplateViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3AD338AF1AAE31D500ECD0F2 /* BuildTemplateViewController.swift */; };
+		3AF090B81B1134AA0058567F /* BranchWatchingViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3AF090B71B1134AA0058567F /* BranchWatchingViewController.swift */; };
 		3AF1B1221AAC621800917EF3 /* UIUtils.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3AF1B1211AAC621800917EF3 /* UIUtils.swift */; };
 		3AF1B1241AAC7CA500917EF3 /* StatusSyncerViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3AF1B1231AAC7CA500917EF3 /* StatusSyncerViewController.swift */; };
 		3AF2B03B1B02C5D700DCF2D6 /* SSHKeyVerification.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3AF2B03A1B02C5D700DCF2D6 /* SSHKeyVerification.swift */; };
@@ -288,6 +289,7 @@
 		3AC553AE1A6313240078CCA6 /* XcodeServerConstants.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = XcodeServerConstants.swift; sourceTree = "<group>"; };
 		3ACB831F1A3BB64F00E285FD /* JSON.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = JSON.swift; sourceTree = "<group>"; };
 		3AD338AF1AAE31D500ECD0F2 /* BuildTemplateViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = BuildTemplateViewController.swift; sourceTree = "<group>"; };
+		3AF090B71B1134AA0058567F /* BranchWatchingViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = BranchWatchingViewController.swift; sourceTree = "<group>"; };
 		3AF1B1211AAC621800917EF3 /* UIUtils.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = UIUtils.swift; sourceTree = "<group>"; };
 		3AF1B1231AAC7CA500917EF3 /* StatusSyncerViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = StatusSyncerViewController.swift; sourceTree = "<group>"; };
 		3AF2B03A1B02C5D700DCF2D6 /* SSHKeyVerification.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SSHKeyVerification.swift; sourceTree = "<group>"; };
@@ -556,6 +558,7 @@
 				3A5B04A91AB4ABEB00F60536 /* TriggerViewController.swift */,
 				3A5B04AB1AB4AC0F00F60536 /* SetupViewController.swift */,
 				3A5B04AF1AB5144700F60536 /* ManualBotManagementViewController.swift */,
+				3AF090B71B1134AA0058567F /* BranchWatchingViewController.swift */,
 				3AB3FDCA1B05644300021197 /* MenuItemManager.swift */,
 			);
 			name = ViewController;
@@ -977,6 +980,7 @@
 				3A46A2CA1B07E28700F0FA4B /* SyncPair.swift in Sources */,
 				3A2F9D861A8FE64900B0DB68 /* LocalSource.swift in Sources */,
 				3A46A2C11B07D8D800F0FA4B /* SyncerBotNaming.swift in Sources */,
+				3AF090B81B1134AA0058567F /* BranchWatchingViewController.swift in Sources */,
 				3A0BC0491B0BFB5D0020AB9F /* SyncPair_Branch_NoBot.swift in Sources */,
 				3A46A2C31B07DCCA00F0FA4B /* SyncerBotManipulation.swift in Sources */,
 				3A5B04AC1AB4AC0F00F60536 /* SetupViewController.swift in Sources */,

--- a/Buildasaur/Base.lproj/Main.storyboard
+++ b/Buildasaur/Base.lproj/Main.storyboard
@@ -670,11 +670,11 @@
             <objects>
                 <viewController title="Buildasaur" id="XfG-lQ-9wD" customClass="MainViewController" customModule="Buildasaur" customModuleProvider="target" sceneMemberID="viewController">
                     <view key="view" id="m2S-Jp-Qdl">
-                        <rect key="frame" x="0.0" y="0.0" width="658" height="486"/>
+                        <rect key="frame" x="0.0" y="0.0" width="658" height="512"/>
                         <autoresizingMask key="autoresizingMask"/>
                         <subviews>
                             <containerView translatesAutoresizingMaskIntoConstraints="NO" id="vRv-Oi-IUa" userLabel="Server View">
-                                <rect key="frame" x="338" y="166" width="300" height="300"/>
+                                <rect key="frame" x="338" y="192" width="300" height="300"/>
                                 <constraints>
                                     <constraint firstAttribute="width" secondItem="vRv-Oi-IUa" secondAttribute="height" multiplier="1:1" id="u6g-Vy-oPM"/>
                                 </constraints>
@@ -683,7 +683,7 @@
                                 </connections>
                             </containerView>
                             <containerView translatesAutoresizingMaskIntoConstraints="NO" id="ilD-N8-ou7" userLabel="Project View">
-                                <rect key="frame" x="20" y="166" width="300" height="300"/>
+                                <rect key="frame" x="20" y="192" width="300" height="300"/>
                                 <constraints>
                                     <constraint firstAttribute="width" secondItem="ilD-N8-ou7" secondAttribute="height" multiplier="1:1" id="VsU-hH-W2M"/>
                                 </constraints>
@@ -692,21 +692,21 @@
                                 </connections>
                             </containerView>
                             <customView translatesAutoresizingMaskIntoConstraints="NO" id="vYq-Em-Glf" userLabel="Separator 1" customClass="SeparatorView" customModule="Buildasaur" customModuleProvider="target">
-                                <rect key="frame" x="328" y="166" width="2" height="300"/>
+                                <rect key="frame" x="328" y="192" width="2" height="300"/>
                                 <constraints>
                                     <constraint firstAttribute="width" constant="2" id="Rqh-Oq-ysa"/>
                                 </constraints>
                             </customView>
                             <customView translatesAutoresizingMaskIntoConstraints="NO" id="riu-7q-ces" userLabel="Separator 2" customClass="SeparatorView" customModule="Buildasaur" customModuleProvider="target">
-                                <rect key="frame" x="20" y="161" width="618" height="2"/>
+                                <rect key="frame" x="20" y="187" width="618" height="2"/>
                                 <constraints>
                                     <constraint firstAttribute="height" constant="2" id="acz-J6-zP3"/>
                                 </constraints>
                             </customView>
                             <containerView translatesAutoresizingMaskIntoConstraints="NO" id="3sW-70-fuG" userLabel="Sync View">
-                                <rect key="frame" x="20" y="10" width="618" height="148"/>
+                                <rect key="frame" x="20" y="10" width="618" height="174"/>
                                 <constraints>
-                                    <constraint firstAttribute="height" constant="148" id="ddY-E0-8na"/>
+                                    <constraint firstAttribute="height" constant="174" id="ddY-E0-8na"/>
                                 </constraints>
                                 <connections>
                                     <segue destination="RHg-5W-Hb1" kind="embed" identifier="embedSyncView" id="kTp-B0-HSt"/>
@@ -981,7 +981,7 @@
                                             <action selector="editButtonTapped:" target="A7n-Q1-s2v" id="9Tf-RO-Oy7"/>
                                         </connections>
                                     </button>
-                                    <button verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="Hm1-sB-msi" userLabel="Edit Button">
+                                    <button verticalHuggingPriority="750" misplaced="YES" translatesAutoresizingMaskIntoConstraints="NO" id="Hm1-sB-msi" userLabel="Edit Button">
                                         <rect key="frame" x="-6" y="139" width="302" height="32"/>
                                         <buttonCell key="cell" type="push" title="Select SSH Public Key" bezelStyle="rounded" alignment="center" borderStyle="border" imageScaling="proportionallyDown" inset="2" id="59P-uj-2qD">
                                             <behavior key="behavior" pushIn="YES" lightByBackground="YES" lightByGray="YES"/>
@@ -1019,7 +1019,7 @@
                                             <color key="backgroundColor" name="textBackgroundColor" catalog="System" colorSpace="catalog"/>
                                         </textFieldCell>
                                     </textField>
-                                    <button verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="91h-XU-pQB" userLabel="Edit Button">
+                                    <button verticalHuggingPriority="750" misplaced="YES" translatesAutoresizingMaskIntoConstraints="NO" id="91h-XU-pQB" userLabel="Edit Button">
                                         <rect key="frame" x="-6" y="114" width="302" height="32"/>
                                         <buttonCell key="cell" type="push" title="Select SSH Private Key" bezelStyle="rounded" alignment="center" borderStyle="border" imageScaling="proportionallyDown" inset="2" id="wWL-q6-LpY">
                                             <behavior key="behavior" pushIn="YES" lightByBackground="YES" lightByGray="YES"/>
@@ -1029,7 +1029,7 @@
                                             <action selector="selectPrivateKeyTapped:" target="A7n-Q1-s2v" id="JYo-8t-iHt"/>
                                         </connections>
                                     </button>
-                                    <secureTextField verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="gjV-E2-9oC">
+                                    <secureTextField verticalHuggingPriority="750" misplaced="YES" translatesAutoresizingMaskIntoConstraints="NO" id="gjV-E2-9oC">
                                         <rect key="frame" x="0.0" y="95" width="290" height="22"/>
                                         <secureTextFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" selectable="YES" editable="YES" sendsActionOnEndEditing="YES" borderStyle="bezel" placeholderString="Your SSH key passphrase (if you have one)" drawsBackground="YES" usesSingleLineMode="YES" id="Yo3-xf-J7S">
                                             <font key="font" metaFont="system"/>
@@ -1040,7 +1040,7 @@
                                             </allowedInputSourceLocales>
                                         </secureTextFieldCell>
                                     </secureTextField>
-                                    <secureTextField verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="LgA-f0-McB">
+                                    <secureTextField verticalHuggingPriority="750" misplaced="YES" translatesAutoresizingMaskIntoConstraints="NO" id="LgA-f0-McB">
                                         <rect key="frame" x="0.0" y="171" width="290" height="22"/>
                                         <secureTextFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" selectable="YES" editable="YES" sendsActionOnEndEditing="YES" borderStyle="bezel" placeholderString="Your GitHub Token" drawsBackground="YES" usesSingleLineMode="YES" id="bYg-Te-bAa">
                                             <font key="font" metaFont="system" size="10"/>
@@ -1341,7 +1341,7 @@
                                 <constraints>
                                     <constraint firstAttribute="height" constant="56" id="7Nb-aF-8GR"/>
                                 </constraints>
-                                <scroller key="horizontalScroller" hidden="YES" verticalHuggingPriority="750" doubleValue="0.5" horizontal="YES" id="dZ6-jK-9d0">
+                                <scroller key="horizontalScroller" verticalHuggingPriority="750" doubleValue="0.5" horizontal="YES" id="dZ6-jK-9d0">
                                     <rect key="frame" x="1" y="117.29037600755692" width="237" height="16"/>
                                     <autoresizingMask key="autoresizingMask"/>
                                 </scroller>
@@ -1437,7 +1437,7 @@
                                 <constraints>
                                     <constraint firstAttribute="height" constant="113" id="akl-ae-qWk"/>
                                 </constraints>
-                                <scroller key="horizontalScroller" hidden="YES" verticalHuggingPriority="750" doubleValue="1" horizontal="YES" id="RFK-qC-17J">
+                                <scroller key="horizontalScroller" verticalHuggingPriority="750" doubleValue="1" horizontal="YES" id="RFK-qC-17J">
                                     <rect key="frame" x="1" y="117.52239549160004" width="237" height="16"/>
                                     <autoresizingMask key="autoresizingMask"/>
                                 </scroller>
@@ -1807,11 +1807,11 @@
             <objects>
                 <viewController id="RHg-5W-Hb1" customClass="StatusSyncerViewController" customModule="Buildasaur" customModuleProvider="target" sceneMemberID="viewController">
                     <view key="view" id="zNe-bD-Pj4">
-                        <rect key="frame" x="0.0" y="0.0" width="618" height="148"/>
+                        <rect key="frame" x="0.0" y="0.0" width="618" height="174"/>
                         <autoresizingMask key="autoresizingMask"/>
                         <subviews>
                             <button verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="Fkq-gK-hvs" userLabel="Edit Button">
-                                <rect key="frame" x="14" y="77" width="97" height="32"/>
+                                <rect key="frame" x="14" y="80" width="97" height="32"/>
                                 <constraints>
                                     <constraint firstAttribute="width" constant="85" id="EMb-CS-lfh"/>
                                 </constraints>
@@ -1824,7 +1824,7 @@
                                 </connections>
                             </button>
                             <progressIndicator horizontalHuggingPriority="750" verticalHuggingPriority="750" maxValue="100" displayedWhenStopped="NO" bezeled="NO" indeterminate="YES" style="spinning" translatesAutoresizingMaskIntoConstraints="NO" id="cYi-gZ-3MX">
-                                <rect key="frame" x="119" y="78" width="32" height="32"/>
+                                <rect key="frame" x="119" y="81" width="32" height="32"/>
                             </progressIndicator>
                             <stepper horizontalHuggingPriority="750" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="XOz-yR-q3G">
                                 <rect key="frame" x="174" y="5" width="19" height="27"/>
@@ -1853,9 +1853,9 @@
                                 </textFieldCell>
                             </textField>
                             <textField verticalHuggingPriority="750" horizontalCompressionResistancePriority="250" setsMaxLayoutWidthAtFirstLayout="YES" translatesAutoresizingMaskIntoConstraints="NO" id="8VZ-bw-dT5">
-                                <rect key="frame" x="212" y="8" width="401" height="135"/>
+                                <rect key="frame" x="212" y="8" width="401" height="161"/>
                                 <constraints>
-                                    <constraint firstAttribute="height" relation="greaterThanOrEqual" constant="135" id="JhA-5r-PLq"/>
+                                    <constraint firstAttribute="height" relation="greaterThanOrEqual" constant="161" id="JhA-5r-PLq"/>
                                 </constraints>
                                 <textFieldCell key="cell" sendsActionOnEndEditing="YES" title="Multiline Label" id="4Nm-0d-uud">
                                     <font key="font" metaFont="system"/>
@@ -1864,7 +1864,7 @@
                                 </textFieldCell>
                             </textField>
                             <button verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="JKR-Sp-m8Y">
-                                <rect key="frame" x="20" y="124" width="169" height="19"/>
+                                <rect key="frame" x="20" y="150" width="169" height="19"/>
                                 <constraints>
                                     <constraint firstAttribute="width" constant="169" id="OyQ-h8-Dln"/>
                                 </constraints>
@@ -1910,15 +1910,27 @@
                                     <action selector="helpPostStatusCommentsButtonTapped:" target="RHg-5W-Hb1" id="EYM-w9-DOh"/>
                                 </connections>
                             </button>
+                            <button verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="SY6-5q-Twj">
+                                <rect key="frame" x="21" y="124" width="169" height="19"/>
+                                <buttonCell key="cell" type="roundTextured" title="Branch Watching" bezelStyle="texturedRounded" alignment="center" controlSize="small" state="on" borderStyle="border" imageScaling="proportionallyDown" inset="2" id="C7J-2v-t41">
+                                    <behavior key="behavior" pushIn="YES" lightByBackground="YES" lightByGray="YES"/>
+                                    <font key="font" metaFont="smallSystem"/>
+                                </buttonCell>
+                                <connections>
+                                    <action selector="branchWatchingTapped:" target="RHg-5W-Hb1" id="2Xk-LX-ywE"/>
+                                </connections>
+                            </button>
                         </subviews>
                         <constraints>
                             <constraint firstItem="A9h-Jh-CP9" firstAttribute="top" secondItem="I34-eZ-a6k" secondAttribute="bottom" constant="6" id="3dX-AM-Tlf"/>
+                            <constraint firstItem="SY6-5q-Twj" firstAttribute="top" secondItem="JKR-Sp-m8Y" secondAttribute="bottom" constant="8" id="F5P-3r-g9T"/>
+                            <constraint firstItem="SY6-5q-Twj" firstAttribute="trailing" secondItem="JKR-Sp-m8Y" secondAttribute="trailing" constant="1" id="FGu-oL-prD"/>
                             <constraint firstItem="8VZ-bw-dT5" firstAttribute="top" secondItem="zNe-bD-Pj4" secondAttribute="top" constant="5" id="Idf-Wk-1a9"/>
                             <constraint firstItem="t3o-Ag-QHY" firstAttribute="centerX" secondItem="BkU-KL-lMX" secondAttribute="centerX" id="JBt-fO-4Qt"/>
                             <constraint firstItem="SL5-bS-Lf1" firstAttribute="trailing" secondItem="I34-eZ-a6k" secondAttribute="trailing" id="K0Z-Rf-B9m"/>
                             <constraint firstAttribute="trailing" secondItem="8VZ-bw-dT5" secondAttribute="trailing" constant="7" id="KhO-CN-dKQ"/>
                             <constraint firstItem="JKR-Sp-m8Y" firstAttribute="top" secondItem="zNe-bD-Pj4" secondAttribute="top" constant="5" id="P0S-FI-EdB"/>
-                            <constraint firstAttribute="centerY" secondItem="Fkq-gK-hvs" secondAttribute="centerY" constant="20" id="Tyj-fy-PKg"/>
+                            <constraint firstAttribute="centerY" secondItem="Fkq-gK-hvs" secondAttribute="centerY" constant="10" id="Tyj-fy-PKg"/>
                             <constraint firstAttribute="bottom" secondItem="8VZ-bw-dT5" secondAttribute="bottom" constant="8" id="VKM-vY-EPh"/>
                             <constraint firstItem="Fkq-gK-hvs" firstAttribute="centerY" secondItem="cYi-gZ-3MX" secondAttribute="centerY" constant="-0.5" id="Vmg-bM-hj9"/>
                             <constraint firstItem="SL5-bS-Lf1" firstAttribute="centerY" secondItem="BkU-KL-lMX" secondAttribute="centerY" constant="-1.5" id="arW-Yk-6ql"/>
@@ -1936,6 +1948,7 @@
                             <constraint firstItem="I34-eZ-a6k" firstAttribute="leading" secondItem="t3o-Ag-QHY" secondAttribute="trailing" constant="12" id="shw-I6-mBG"/>
                             <constraint firstItem="Fkq-gK-hvs" firstAttribute="leading" secondItem="zNe-bD-Pj4" secondAttribute="leading" constant="20" id="tAH-BV-LCf"/>
                             <constraint firstItem="cYi-gZ-3MX" firstAttribute="leading" secondItem="Fkq-gK-hvs" secondAttribute="trailing" constant="14" id="wg4-z7-3io"/>
+                            <constraint firstItem="SY6-5q-Twj" firstAttribute="leading" secondItem="JKR-Sp-m8Y" secondAttribute="leading" constant="1" id="xlq-G3-mnt"/>
                         </constraints>
                     </view>
                     <connections>
@@ -1951,7 +1964,7 @@
                 </viewController>
                 <customObject id="hcU-DC-I36" userLabel="First Responder" customClass="NSResponder" sceneMemberID="firstResponder"/>
             </objects>
-            <point key="canvasLocation" x="104" y="1284"/>
+            <point key="canvasLocation" x="104" y="1297"/>
         </scene>
         <!--Manual Bot Management View Controller-->
         <scene sceneID="1BI-BT-Scb">
@@ -2089,7 +2102,7 @@
                 </viewController>
                 <customObject id="KOh-9c-iJq" userLabel="First Responder" customClass="NSResponder" sceneMemberID="firstResponder"/>
             </objects>
-            <point key="canvasLocation" x="313" y="1599.5"/>
+            <point key="canvasLocation" x="791" y="1627.5"/>
         </scene>
     </scenes>
     <resources>

--- a/Buildasaur/Base.lproj/Main.storyboard
+++ b/Buildasaur/Base.lproj/Main.storyboard
@@ -2163,7 +2163,7 @@
                                             <color key="backgroundColor" name="controlBackgroundColor" catalog="System" colorSpace="catalog"/>
                                             <color key="gridColor" name="gridColor" catalog="System" colorSpace="catalog"/>
                                             <tableColumns>
-                                                <tableColumn identifier="name" width="228" minWidth="40" maxWidth="228" id="Yfx-5F-5Pp">
+                                                <tableColumn identifier="name" width="220" minWidth="40" maxWidth="228" id="Yfx-5F-5Pp">
                                                     <tableHeaderCell key="headerCell" lineBreakMode="truncatingTail" borderStyle="border" alignment="left">
                                                         <font key="font" metaFont="smallSystem"/>
                                                         <color key="textColor" name="headerTextColor" catalog="System" colorSpace="catalog"/>
@@ -2186,21 +2186,21 @@
                                                         <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
                                                         <font key="font" metaFont="system"/>
                                                         <connections>
-                                                            <action selector="testDevicesTableViewRowCheckboxTapped:" target="gBo-v0-Miz" id="d4K-54-Ud5"/>
+                                                            <action selector="branchesTableViewRowCheckboxTapped:" target="H0w-7S-xXi" id="aRq-gf-qKT"/>
                                                         </connections>
                                                     </buttonCell>
                                                     <tableColumnResizingMask key="resizingMask" resizeWithTable="YES" userResizable="YES"/>
                                                 </tableColumn>
                                             </tableColumns>
                                             <connections>
-                                                <outlet property="dataSource" destination="gBo-v0-Miz" id="Bo7-mW-UlG"/>
-                                                <outlet property="delegate" destination="gBo-v0-Miz" id="mqn-52-Gnd"/>
+                                                <outlet property="dataSource" destination="H0w-7S-xXi" id="o53-Zz-IGO"/>
+                                                <outlet property="delegate" destination="H0w-7S-xXi" id="hIj-dU-CGj"/>
                                             </connections>
                                         </tableView>
                                     </subviews>
                                     <color key="backgroundColor" name="controlBackgroundColor" catalog="System" colorSpace="catalog"/>
                                 </clipView>
-                                <scroller key="horizontalScroller" verticalHuggingPriority="750" horizontal="YES" id="zLT-KA-AWK">
+                                <scroller key="horizontalScroller" hidden="YES" verticalHuggingPriority="750" horizontal="YES" id="zLT-KA-AWK">
                                     <rect key="frame" x="1" y="117.52239549160004" width="237" height="16"/>
                                     <autoresizingMask key="autoresizingMask"/>
                                 </scroller>
@@ -2227,6 +2227,7 @@
                     </view>
                     <connections>
                         <outlet property="branchActivityIndicator" destination="SAg-Zh-mDU" id="y4C-yR-OVa"/>
+                        <outlet property="branchesTableView" destination="jDu-Ec-web" id="jGZ-XE-ZjI"/>
                     </connections>
                 </viewController>
                 <customObject id="JCM-p0-AyE" userLabel="First Responder" customClass="NSResponder" sceneMemberID="firstResponder"/>

--- a/Buildasaur/Base.lproj/Main.storyboard
+++ b/Buildasaur/Base.lproj/Main.storyboard
@@ -981,8 +981,8 @@
                                             <action selector="editButtonTapped:" target="A7n-Q1-s2v" id="9Tf-RO-Oy7"/>
                                         </connections>
                                     </button>
-                                    <button verticalHuggingPriority="750" misplaced="YES" translatesAutoresizingMaskIntoConstraints="NO" id="Hm1-sB-msi" userLabel="Edit Button">
-                                        <rect key="frame" x="-6" y="139" width="302" height="32"/>
+                                    <button verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="Hm1-sB-msi" userLabel="Edit Button">
+                                        <rect key="frame" x="-6" y="143" width="302" height="32"/>
                                         <buttonCell key="cell" type="push" title="Select SSH Public Key" bezelStyle="rounded" alignment="center" borderStyle="border" imageScaling="proportionallyDown" inset="2" id="59P-uj-2qD">
                                             <behavior key="behavior" pushIn="YES" lightByBackground="YES" lightByGray="YES"/>
                                             <font key="font" metaFont="system"/>
@@ -1019,8 +1019,8 @@
                                             <color key="backgroundColor" name="textBackgroundColor" catalog="System" colorSpace="catalog"/>
                                         </textFieldCell>
                                     </textField>
-                                    <button verticalHuggingPriority="750" misplaced="YES" translatesAutoresizingMaskIntoConstraints="NO" id="91h-XU-pQB" userLabel="Edit Button">
-                                        <rect key="frame" x="-6" y="114" width="302" height="32"/>
+                                    <button verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="91h-XU-pQB" userLabel="Edit Button">
+                                        <rect key="frame" x="-6" y="118" width="302" height="32"/>
                                         <buttonCell key="cell" type="push" title="Select SSH Private Key" bezelStyle="rounded" alignment="center" borderStyle="border" imageScaling="proportionallyDown" inset="2" id="wWL-q6-LpY">
                                             <behavior key="behavior" pushIn="YES" lightByBackground="YES" lightByGray="YES"/>
                                             <font key="font" metaFont="system"/>
@@ -1029,8 +1029,8 @@
                                             <action selector="selectPrivateKeyTapped:" target="A7n-Q1-s2v" id="JYo-8t-iHt"/>
                                         </connections>
                                     </button>
-                                    <secureTextField verticalHuggingPriority="750" misplaced="YES" translatesAutoresizingMaskIntoConstraints="NO" id="gjV-E2-9oC">
-                                        <rect key="frame" x="0.0" y="95" width="290" height="22"/>
+                                    <secureTextField verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="gjV-E2-9oC">
+                                        <rect key="frame" x="0.0" y="99" width="290" height="22"/>
                                         <secureTextFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" selectable="YES" editable="YES" sendsActionOnEndEditing="YES" borderStyle="bezel" placeholderString="Your SSH key passphrase (if you have one)" drawsBackground="YES" usesSingleLineMode="YES" id="Yo3-xf-J7S">
                                             <font key="font" metaFont="system"/>
                                             <color key="textColor" name="textColor" catalog="System" colorSpace="catalog"/>
@@ -1040,8 +1040,8 @@
                                             </allowedInputSourceLocales>
                                         </secureTextFieldCell>
                                     </secureTextField>
-                                    <secureTextField verticalHuggingPriority="750" misplaced="YES" translatesAutoresizingMaskIntoConstraints="NO" id="LgA-f0-McB">
-                                        <rect key="frame" x="0.0" y="171" width="290" height="22"/>
+                                    <secureTextField verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="LgA-f0-McB">
+                                        <rect key="frame" x="0.0" y="175" width="290" height="18"/>
                                         <secureTextFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" selectable="YES" editable="YES" sendsActionOnEndEditing="YES" borderStyle="bezel" placeholderString="Your GitHub Token" drawsBackground="YES" usesSingleLineMode="YES" id="bYg-Te-bAa">
                                             <font key="font" metaFont="system" size="10"/>
                                             <color key="textColor" name="textColor" catalog="System" colorSpace="catalog"/>
@@ -1341,7 +1341,7 @@
                                 <constraints>
                                     <constraint firstAttribute="height" constant="56" id="7Nb-aF-8GR"/>
                                 </constraints>
-                                <scroller key="horizontalScroller" verticalHuggingPriority="750" doubleValue="0.5" horizontal="YES" id="dZ6-jK-9d0">
+                                <scroller key="horizontalScroller" hidden="YES" verticalHuggingPriority="750" doubleValue="0.5" horizontal="YES" id="dZ6-jK-9d0">
                                     <rect key="frame" x="1" y="117.29037600755692" width="237" height="16"/>
                                     <autoresizingMask key="autoresizingMask"/>
                                 </scroller>
@@ -1437,7 +1437,7 @@
                                 <constraints>
                                     <constraint firstAttribute="height" constant="113" id="akl-ae-qWk"/>
                                 </constraints>
-                                <scroller key="horizontalScroller" verticalHuggingPriority="750" doubleValue="1" horizontal="YES" id="RFK-qC-17J">
+                                <scroller key="horizontalScroller" hidden="YES" verticalHuggingPriority="750" doubleValue="1" horizontal="YES" id="RFK-qC-17J">
                                     <rect key="frame" x="1" y="117.52239549160004" width="237" height="16"/>
                                     <autoresizingMask key="autoresizingMask"/>
                                 </scroller>
@@ -1960,6 +1960,7 @@
                         <outlet property="syncIntervalStepper" destination="XOz-yR-q3G" id="ZgF-2G-Jyb"/>
                         <outlet property="syncIntervalTextField" destination="A9h-Jh-CP9" id="GAf-Ie-yg8"/>
                         <segue destination="4et-cp-hnb" kind="modal" identifier="showManual" id="2HZ-dc-2CX"/>
+                        <segue destination="H0w-7S-xXi" kind="modal" identifier="showBranchWatching" id="tGu-vj-Qes"/>
                     </connections>
                 </viewController>
                 <customObject id="hcU-DC-I36" userLabel="First Responder" customClass="NSResponder" sceneMemberID="firstResponder"/>
@@ -2103,6 +2104,134 @@
                 <customObject id="KOh-9c-iJq" userLabel="First Responder" customClass="NSResponder" sceneMemberID="firstResponder"/>
             </objects>
             <point key="canvasLocation" x="791" y="1627.5"/>
+        </scene>
+        <!--Branch Watching View Controller-->
+        <scene sceneID="bAU-fS-U9a">
+            <objects>
+                <viewController id="H0w-7S-xXi" customClass="BranchWatchingViewController" customModule="Buildasaur" customModuleProvider="target" sceneMemberID="viewController">
+                    <view key="view" id="Wgg-Ri-IDL">
+                        <rect key="frame" x="0.0" y="0.0" width="450" height="340"/>
+                        <autoresizingMask key="autoresizingMask"/>
+                        <subviews>
+                            <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="JGX-Vl-8cd">
+                                <rect key="frame" x="143" y="298" width="164" height="22"/>
+                                <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" alignment="center" title="Watched Branches" id="11g-YC-AK3">
+                                    <font key="font" metaFont="system" size="18"/>
+                                    <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
+                                    <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
+                                </textFieldCell>
+                            </textField>
+                            <progressIndicator horizontalHuggingPriority="750" verticalHuggingPriority="750" maxValue="100" displayedWhenStopped="NO" bezeled="NO" indeterminate="YES" controlSize="small" style="spinning" translatesAutoresizingMaskIntoConstraints="NO" id="SAg-Zh-mDU">
+                                <rect key="frame" x="121" y="301" width="16" height="16"/>
+                            </progressIndicator>
+                            <button verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="YkO-Wz-Ncg">
+                                <rect key="frame" x="69" y="18" width="116" height="25"/>
+                                <constraints>
+                                    <constraint firstAttribute="width" constant="116" id="UPy-bc-FF9"/>
+                                </constraints>
+                                <buttonCell key="cell" type="roundTextured" title="Done" bezelStyle="texturedRounded" alignment="center" state="on" borderStyle="border" imageScaling="proportionallyDown" inset="2" id="Pr1-w9-wNn">
+                                    <behavior key="behavior" pushIn="YES" lightByBackground="YES" lightByGray="YES"/>
+                                    <font key="font" metaFont="system"/>
+                                </buttonCell>
+                                <connections>
+                                    <action selector="doneTapped:" target="H0w-7S-xXi" id="Zt7-Oj-Buz"/>
+                                </connections>
+                            </button>
+                            <button verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="baK-Qc-zQp">
+                                <rect key="frame" x="266" y="18" width="116" height="25"/>
+                                <constraints>
+                                    <constraint firstAttribute="width" constant="116" id="dwa-ym-KWc"/>
+                                </constraints>
+                                <buttonCell key="cell" type="roundTextured" title="Cancel" bezelStyle="texturedRounded" alignment="center" state="on" borderStyle="border" imageScaling="proportionallyDown" inset="2" id="d46-Q8-RjQ">
+                                    <behavior key="behavior" pushIn="YES" lightByBackground="YES" lightByGray="YES"/>
+                                    <font key="font" metaFont="system"/>
+                                </buttonCell>
+                                <connections>
+                                    <action selector="cancelTapped:" target="H0w-7S-xXi" id="B8h-qe-Q3f"/>
+                                </connections>
+                            </button>
+                            <scrollView autohidesScrollers="YES" horizontalLineScroll="19" horizontalPageScroll="10" verticalLineScroll="19" verticalPageScroll="10" usesPredominantAxisScrolling="NO" translatesAutoresizingMaskIntoConstraints="NO" id="vg9-HZ-Xv0">
+                                <rect key="frame" x="50" y="60" width="351" height="230"/>
+                                <clipView key="contentView" id="3Xt-4Y-pgX">
+                                    <rect key="frame" x="1" y="0.0" width="238" height="134"/>
+                                    <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+                                    <subviews>
+                                        <tableView verticalHuggingPriority="750" allowsExpansionToolTips="YES" columnAutoresizingStyle="lastColumnOnly" alternatingRowBackgroundColors="YES" columnReordering="NO" columnSelection="YES" columnResizing="NO" multipleSelection="NO" autosaveColumns="NO" id="jDu-Ec-web">
+                                            <rect key="frame" x="0.0" y="0.0" width="349" height="19"/>
+                                            <autoresizingMask key="autoresizingMask"/>
+                                            <size key="intercellSpacing" width="3" height="2"/>
+                                            <color key="backgroundColor" name="controlBackgroundColor" catalog="System" colorSpace="catalog"/>
+                                            <color key="gridColor" name="gridColor" catalog="System" colorSpace="catalog"/>
+                                            <tableColumns>
+                                                <tableColumn identifier="name" width="228" minWidth="40" maxWidth="228" id="Yfx-5F-5Pp">
+                                                    <tableHeaderCell key="headerCell" lineBreakMode="truncatingTail" borderStyle="border" alignment="left">
+                                                        <font key="font" metaFont="smallSystem"/>
+                                                        <color key="textColor" name="headerTextColor" catalog="System" colorSpace="catalog"/>
+                                                        <color key="backgroundColor" name="headerColor" catalog="System" colorSpace="catalog"/>
+                                                    </tableHeaderCell>
+                                                    <textFieldCell key="dataCell" lineBreakMode="truncatingTail" selectable="YES" editable="YES" alignment="left" title="Text Cell" id="Ts5-GI-eyd">
+                                                        <font key="font" metaFont="system"/>
+                                                        <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
+                                                        <color key="backgroundColor" name="controlBackgroundColor" catalog="System" colorSpace="catalog"/>
+                                                    </textFieldCell>
+                                                    <tableColumnResizingMask key="resizingMask" resizeWithTable="YES" userResizable="YES"/>
+                                                </tableColumn>
+                                                <tableColumn identifier="enabled" width="116" minWidth="50" maxWidth="123" id="GG0-jU-xdT">
+                                                    <tableHeaderCell key="headerCell" lineBreakMode="truncatingTail" borderStyle="border" alignment="left">
+                                                        <font key="font" metaFont="smallSystem"/>
+                                                        <color key="textColor" name="headerTextColor" catalog="System" colorSpace="catalog"/>
+                                                        <color key="backgroundColor" name="headerColor" catalog="System" colorSpace="catalog"/>
+                                                    </tableHeaderCell>
+                                                    <buttonCell key="dataCell" type="check" title="Watch and Test" bezelStyle="regularSquare" imagePosition="left" inset="2" id="Trs-9M-n2R">
+                                                        <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
+                                                        <font key="font" metaFont="system"/>
+                                                        <connections>
+                                                            <action selector="testDevicesTableViewRowCheckboxTapped:" target="gBo-v0-Miz" id="d4K-54-Ud5"/>
+                                                        </connections>
+                                                    </buttonCell>
+                                                    <tableColumnResizingMask key="resizingMask" resizeWithTable="YES" userResizable="YES"/>
+                                                </tableColumn>
+                                            </tableColumns>
+                                            <connections>
+                                                <outlet property="dataSource" destination="gBo-v0-Miz" id="Bo7-mW-UlG"/>
+                                                <outlet property="delegate" destination="gBo-v0-Miz" id="mqn-52-Gnd"/>
+                                            </connections>
+                                        </tableView>
+                                    </subviews>
+                                    <color key="backgroundColor" name="controlBackgroundColor" catalog="System" colorSpace="catalog"/>
+                                </clipView>
+                                <scroller key="horizontalScroller" verticalHuggingPriority="750" horizontal="YES" id="zLT-KA-AWK">
+                                    <rect key="frame" x="1" y="117.52239549160004" width="237" height="16"/>
+                                    <autoresizingMask key="autoresizingMask"/>
+                                </scroller>
+                                <scroller key="verticalScroller" hidden="YES" verticalHuggingPriority="750" horizontal="NO" id="9zl-pA-Pe8">
+                                    <rect key="frame" x="224" y="17" width="15" height="102"/>
+                                    <autoresizingMask key="autoresizingMask"/>
+                                </scroller>
+                            </scrollView>
+                        </subviews>
+                        <constraints>
+                            <constraint firstAttribute="bottom" secondItem="YkO-Wz-Ncg" secondAttribute="bottom" constant="20" id="1Y6-EX-GlU"/>
+                            <constraint firstAttribute="centerX" secondItem="JGX-Vl-8cd" secondAttribute="centerX" id="2i3-90-lZM"/>
+                            <constraint firstItem="JGX-Vl-8cd" firstAttribute="top" secondItem="Wgg-Ri-IDL" secondAttribute="top" constant="20" id="2zl-E8-WVM"/>
+                            <constraint firstItem="vg9-HZ-Xv0" firstAttribute="top" secondItem="JGX-Vl-8cd" secondAttribute="bottom" constant="8" id="9kH-4Z-osO"/>
+                            <constraint firstItem="YkO-Wz-Ncg" firstAttribute="leading" secondItem="Wgg-Ri-IDL" secondAttribute="leading" constant="69" id="Axz-BO-JlU"/>
+                            <constraint firstItem="SAg-Zh-mDU" firstAttribute="centerY" secondItem="JGX-Vl-8cd" secondAttribute="centerY" id="DUP-TA-rhC"/>
+                            <constraint firstItem="baK-Qc-zQp" firstAttribute="leading" secondItem="YkO-Wz-Ncg" secondAttribute="trailing" constant="81" id="QGh-74-KgS"/>
+                            <constraint firstItem="vg9-HZ-Xv0" firstAttribute="leading" secondItem="Wgg-Ri-IDL" secondAttribute="leading" constant="50" id="S7x-8X-1Kq"/>
+                            <constraint firstItem="JGX-Vl-8cd" firstAttribute="leading" secondItem="SAg-Zh-mDU" secondAttribute="trailing" constant="8" id="Ufw-of-bxF"/>
+                            <constraint firstAttribute="trailing" secondItem="vg9-HZ-Xv0" secondAttribute="trailing" constant="49" id="dAe-Dd-LpO"/>
+                            <constraint firstItem="YkO-Wz-Ncg" firstAttribute="top" secondItem="vg9-HZ-Xv0" secondAttribute="bottom" constant="18" id="gZb-qm-2i6"/>
+                            <constraint firstItem="baK-Qc-zQp" firstAttribute="top" secondItem="YkO-Wz-Ncg" secondAttribute="top" id="is6-fU-6dX"/>
+                        </constraints>
+                    </view>
+                    <connections>
+                        <outlet property="branchActivityIndicator" destination="SAg-Zh-mDU" id="y4C-yR-OVa"/>
+                    </connections>
+                </viewController>
+                <customObject id="JCM-p0-AyE" userLabel="First Responder" customClass="NSResponder" sceneMemberID="firstResponder"/>
+            </objects>
+            <point key="canvasLocation" x="249" y="1742"/>
         </scene>
     </scenes>
     <resources>

--- a/Buildasaur/BranchWatchingViewController.swift
+++ b/Buildasaur/BranchWatchingViewController.swift
@@ -12,21 +12,22 @@ import AppKit
 import BuildaGitServer
 import BuildaUtils
 
-class BranchWatchingViewController: NSViewController {
+class BranchWatchingViewController: NSViewController, NSTableViewDelegate, NSTableViewDataSource {
     
     //these two must be set before viewDidLoad by its presenting view controller
     var syncer: HDGitHubXCBotSyncer!
-    var watchedBranchNames: [String]!
+    var watchedBranchNames: Set<String>!
     
     private var branches: [Branch] = []
     
     @IBOutlet weak var branchActivityIndicator: NSProgressIndicator!
-    
+    @IBOutlet weak var branchesTableView: NSTableView!
+
     override func viewDidLoad() {
         super.viewDidLoad()
         
         assert(self.syncer != nil, "Syncer has not been set")
-        self.watchedBranchNames = self.syncer.watchedBranchNames
+        self.watchedBranchNames = Set(self.syncer.watchedBranchNames)
     }
     
     override func viewWillAppear() {
@@ -37,6 +38,8 @@ class BranchWatchingViewController: NSViewController {
             if let error = error {
                 UIUtils.showAlertWithError(error)
             }
+            
+            self.branchesTableView.reloadData()
         }
     }
     
@@ -64,8 +67,57 @@ class BranchWatchingViewController: NSViewController {
     
     @IBAction func doneTapped(sender: AnyObject) {
         //save the now-selected watched branches to the syncer
-        self.syncer.watchedBranchNames = self.watchedBranchNames
+        self.syncer.watchedBranchNames = Array(self.watchedBranchNames)
         StorageManager.sharedInstance.saveSyncers() //think of a better way to force saving
         self.dismissController(nil)
     }
+    
+    //MARK: branches table view
+    
+    func numberOfRowsInTableView(tableView: NSTableView) -> Int {
+        
+        if tableView == self.branchesTableView {
+            return self.branches.count
+        }
+        return 0
+    }
+    
+    func tableView(tableView: NSTableView, objectValueForTableColumn tableColumn: NSTableColumn?, row: Int) -> AnyObject? {
+        
+        if tableView == self.branchesTableView {
+            
+            switch tableColumn!.identifier {
+            case "name":
+                
+                let branch = self.branches[row]
+                return branch.name
+            case "enabled":
+                
+                let branch = self.branches[row]
+                return self.watchedBranchNames.contains(branch.name)
+            default:
+                return nil
+            }
+        }
+        return nil
+    }
+    
+    @IBAction func branchesTableViewRowCheckboxTapped(sender: AnyObject) {
+        
+        //toggle selection in model
+        let branch = self.branches[self.branchesTableView.selectedRow]
+        let branchName = branch.name
+        
+        //see if we are checking or unchecking
+        let previouslyEnabled = self.watchedBranchNames.contains(branchName)
+        
+        if previouslyEnabled {
+            //disable
+            self.watchedBranchNames.remove(branchName)
+        } else {
+            //enable
+            self.watchedBranchNames.insert(branchName)
+        }
+    }
+
 }

--- a/Buildasaur/BranchWatchingViewController.swift
+++ b/Buildasaur/BranchWatchingViewController.swift
@@ -1,0 +1,71 @@
+//
+//  BranchWatchingViewController.swift
+//  Buildasaur
+//
+//  Created by Honza Dvorsky on 23/05/2015.
+//  Copyright (c) 2015 Honza Dvorsky. All rights reserved.
+//
+
+import Foundation
+
+import AppKit
+import BuildaGitServer
+import BuildaUtils
+
+class BranchWatchingViewController: NSViewController {
+    
+    //these two must be set before viewDidLoad by its presenting view controller
+    var syncer: HDGitHubXCBotSyncer!
+    var watchedBranchNames: [String]!
+    
+    private var branches: [Branch] = []
+    
+    @IBOutlet weak var branchActivityIndicator: NSProgressIndicator!
+    
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        
+        assert(self.syncer != nil, "Syncer has not been set")
+        self.watchedBranchNames = self.syncer.watchedBranchNames
+    }
+    
+    override func viewWillAppear() {
+        super.viewWillAppear()
+        
+        self.fetchBranches { (branches, error) -> () in
+            
+            if let error = error {
+                UIUtils.showAlertWithError(error)
+            }
+        }
+    }
+    
+    func fetchBranches(completion: ([Branch]?, NSError?) -> ()) {
+        
+        self.branchActivityIndicator.startAnimation(nil)
+        let repoName = self.syncer.localSource.githubRepoName()!
+        self.syncer.github.getBranchesOfRepo(repoName, completion: { (branches, error) -> () in
+            
+            NSOperationQueue.mainQueue().addOperationWithBlock({ () -> Void in
+                
+                if let branches = branches {
+                    self.branches = branches
+                }
+                
+                completion(branches, error)
+                self.branchActivityIndicator.stopAnimation(nil)
+            })
+        })
+    }
+    
+    @IBAction func cancelTapped(sender: AnyObject) {
+        self.dismissController(nil)
+    }
+    
+    @IBAction func doneTapped(sender: AnyObject) {
+        //save the now-selected watched branches to the syncer
+        self.syncer.watchedBranchNames = self.watchedBranchNames
+        StorageManager.sharedInstance.saveSyncers() //think of a better way to force saving
+        self.dismissController(nil)
+    }
+}

--- a/Buildasaur/CommonExtensions.swift
+++ b/Buildasaur/CommonExtensions.swift
@@ -8,7 +8,6 @@
 
 import Foundation
 
-
 func firstNonNil<T>(objects: [T?]) -> T? {
     for i in objects {
         if let i = i {
@@ -69,6 +68,19 @@ extension Array {
             }
             completion(returnedValues)
         }
+    }
+}
+
+extension Array {
+    
+    //dictionarify an array for fast lookup by a specific key
+    func toDictionary(key: (T) -> String) -> [String: T] {
+        
+        var dict = [String: T]()
+        for i in self {
+            dict[key(i)] = i
+        }
+        return dict
     }
 }
 

--- a/Buildasaur/HDGitHubXCBotSyncer.swift
+++ b/Buildasaur/HDGitHubXCBotSyncer.swift
@@ -25,18 +25,19 @@ public class HDGitHubXCBotSyncer : Syncer {
     let localSource: LocalSource!
     let waitForLttm: Bool
     let postStatusComments: Bool
-    public var watchedBranchNames: [String] = []
+    public var watchedBranchNames: [String]
     
     public typealias GitHubStatusAndComment = (status: Status, comment: String?)
     
     public init(integrationServer: XcodeServer, sourceServer: GitHubServer, localSource: LocalSource,
-        syncInterval: NSTimeInterval, waitForLttm: Bool, postStatusComments: Bool) {
+        syncInterval: NSTimeInterval, waitForLttm: Bool, postStatusComments: Bool, watchedBranchNames: [String]) {
             
             self.github = sourceServer
             self.xcodeServer = integrationServer
             self.localSource = localSource
             self.waitForLttm = waitForLttm
             self.postStatusComments = postStatusComments
+            self.watchedBranchNames = watchedBranchNames
             super.init(syncInterval: syncInterval)
     }
     
@@ -54,6 +55,7 @@ public class HDGitHubXCBotSyncer : Syncer {
             self.xcodeServer = XcodeServerFactory.server(serverConfig)
             self.waitForLttm = json.optionalBoolForKey("wait_for_lttm") ?? true
             self.postStatusComments = json.optionalBoolForKey("post_status_comments") ?? true
+            self.watchedBranchNames = json.optionalArrayForKey("watched_branches") as? [String] ?? []
             super.init(syncInterval: syncInterval)
             
         } else {
@@ -63,6 +65,7 @@ public class HDGitHubXCBotSyncer : Syncer {
             self.localSource = nil
             self.waitForLttm = true
             self.postStatusComments = true
+            self.watchedBranchNames = []
             super.init(syncInterval: 0)
             return nil
         }
@@ -76,6 +79,7 @@ public class HDGitHubXCBotSyncer : Syncer {
         dict["server_host"] = self.xcodeServer.config.host
         dict["wait_for_lttm"] = self.waitForLttm
         dict["post_status_comments"] = self.postStatusComments
+        dict["watched_branches"] = self.watchedBranchNames
         return dict
     }
     

--- a/Buildasaur/HDGitHubXCBotSyncer.swift
+++ b/Buildasaur/HDGitHubXCBotSyncer.swift
@@ -278,9 +278,12 @@ public class HDGitHubXCBotSyncer : Syncer {
             let branchesDictionary = branches.toDictionary { $0.name }
             
             //filter just the ones we want
-            let branchesToWatch = self.watchedBranchNames.filter({ branchesDictionary[$0] != nil }).map({ branchesDictionary[$0]! })
+            let foundBranchesToWatch = self.watchedBranchNames.filter({ branchesDictionary[$0] != nil })
+            let branchesToWatch = foundBranchesToWatch.map({ branchesDictionary[$0]! })
             
-            //TODO: what do we do with deleted branches still in the list of branches to watch long term?
+            //what do we do with deleted branches still in the list of branches to watch long term?
+            //we unwatch them right here by just keeping the valid, found branches
+            self.watchedBranchNames = foundBranchesToWatch
             
             //go through the branches to track
             for branch in branchesToWatch {

--- a/Buildasaur/MainViewController.swift
+++ b/Buildasaur/MainViewController.swift
@@ -30,7 +30,7 @@ class MainViewController: NSViewController, NSTableViewDataSource, StatusSibling
         super.viewWillAppear()
         
         if let window = self.view.window {
-            window.minSize = CGSizeMake(658, 486)
+            window.minSize = CGSizeMake(658, 512)
             let version = NSBundle.mainBundle().infoDictionary!["CFBundleShortVersionString"] as! String
             window.title = "Buildasaur \(version), at your service"
         }

--- a/Buildasaur/StatusSyncerViewController.swift
+++ b/Buildasaur/StatusSyncerViewController.swift
@@ -180,12 +180,11 @@ class StatusSyncerViewController: StatusViewController, SyncerDelegate {
     
     @IBAction func branchWatchingTapped(sender: AnyObject) {
         
-        assertionFailure("not yet implemented")
-//        if let syncer = self.syncer() {
-//            self.performSegueWithIdentifier("showManual", sender: self)
-//        } else {
-//            UIUtils.showAlertWithText("Syncer must be created first. Click 'Start' and try again.")
-//        }
+         if let syncer = self.syncer() {
+            self.performSegueWithIdentifier("showBranchWatching", sender: self)
+        } else {
+            UIUtils.showAlertWithText("Syncer must be created first. Click 'Start' and try again.")
+        }
     }
     
     @IBAction func manualBotManagementTapped(sender: AnyObject) {
@@ -220,13 +219,21 @@ class StatusSyncerViewController: StatusViewController, SyncerDelegate {
             manual.syncer = self.syncer()!
         }
         
+        if let branchWatching = segue.destinationController as? BranchWatchingViewController {
+            
+            branchWatching.syncer = self.syncer()!
+        }
     }
     
     func startSyncing() {
         
         //create a syncer, delete the old one and kick it off
+        let oldWatchedBranchNames: [String]
         if let syncer = self.syncer() {
             self.storageManager.removeSyncer(syncer)
+            oldWatchedBranchNames = syncer.watchedBranchNames
+        } else {
+            oldWatchedBranchNames = []
         }
         
         let waitForLttm = self.lttmToggle.state == NSOnState
@@ -235,8 +242,13 @@ class StatusSyncerViewController: StatusViewController, SyncerDelegate {
         let project = self.delegate.getProjectStatusViewController().project()!
         let serverConfig = self.delegate.getServerStatusViewController().serverConfig()!
         
-        if let syncer = self.storageManager.addSyncer(syncInterval, waitForLttm: waitForLttm, postStatusComments: postStatusComments,
-            project: project, serverConfig: serverConfig) {
+        if let syncer = self.storageManager.addSyncer(
+            syncInterval,
+            waitForLttm: waitForLttm,
+            postStatusComments: postStatusComments,
+            project: project,
+            serverConfig: serverConfig,
+            watchedBranchNames: oldWatchedBranchNames) {
             
             syncer.active = true
             

--- a/Buildasaur/StatusSyncerViewController.swift
+++ b/Buildasaur/StatusSyncerViewController.swift
@@ -178,6 +178,16 @@ class StatusSyncerViewController: StatusViewController, SyncerDelegate {
         }
     }
     
+    @IBAction func branchWatchingTapped(sender: AnyObject) {
+        
+        assertionFailure("not yet implemented")
+//        if let syncer = self.syncer() {
+//            self.performSegueWithIdentifier("showManual", sender: self)
+//        } else {
+//            UIUtils.showAlertWithText("Syncer must be created first. Click 'Start' and try again.")
+//        }
+    }
+    
     @IBAction func manualBotManagementTapped(sender: AnyObject) {
         
         if let syncer = self.syncer() {

--- a/Buildasaur/StorageManager.swift
+++ b/Buildasaur/StorageManager.swift
@@ -53,7 +53,7 @@ class StorageManager {
     }
     
     func addSyncer(syncInterval: NSTimeInterval, waitForLttm: Bool, postStatusComments: Bool,
-        project: LocalSource, serverConfig: XcodeServerConfig) -> HDGitHubXCBotSyncer? {
+        project: LocalSource, serverConfig: XcodeServerConfig, watchedBranchNames: [String]) -> HDGitHubXCBotSyncer? {
 
         if syncInterval <= 0 {
             Log.error("Sync interval must be > 0 seconds.")
@@ -62,8 +62,14 @@ class StorageManager {
         
         let xcodeServer = XcodeServerFactory.server(serverConfig)
         let github = GitHubFactory.server(project.githubToken)
-        let syncer = HDGitHubXCBotSyncer(integrationServer: xcodeServer, sourceServer: github, localSource: project,
-            syncInterval: syncInterval, waitForLttm: waitForLttm, postStatusComments: postStatusComments)
+        let syncer = HDGitHubXCBotSyncer(
+            integrationServer: xcodeServer,
+            sourceServer: github,
+            localSource: project,
+            syncInterval: syncInterval,
+            waitForLttm: waitForLttm,
+            postStatusComments: postStatusComments,
+            watchedBranchNames: watchedBranchNames)
         self.syncers.append(syncer)
         return syncer
     }

--- a/Buildasaur/SyncPair.swift
+++ b/Buildasaur/SyncPair.swift
@@ -31,7 +31,7 @@ public class SyncPair {
     final func start(completion: Completion) {
         
         let start = NSDate()
-        Log.verbose("SyncPair \(self.syncPairName()) started sync")
+//        Log.verbose("SyncPair \(self.syncPairName()) started sync")
         
         self.sync { (error) -> () in
             

--- a/Buildasaur/SyncPairBranchResolver.swift
+++ b/Buildasaur/SyncPairBranchResolver.swift
@@ -1,0 +1,18 @@
+//
+//  SyncPairBranchResolver.swift
+//  Buildasaur
+//
+//  Created by Honza Dvorsky on 19/05/15.
+//  Copyright (c) 2015 Honza Dvorsky. All rights reserved.
+//
+
+import Foundation
+import BuildaCIServer
+import BuildaGitServer
+import BuildaUtils
+
+public class SyncPairBranchResolver: SyncPairResolver {
+    
+    
+}
+

--- a/Buildasaur/SyncPairExtensions.swift
+++ b/Buildasaur/SyncPairExtensions.swift
@@ -1,0 +1,72 @@
+//
+//  SyncPairExtensions.swift
+//  Buildasaur
+//
+//  Created by Honza Dvorsky on 19/05/15.
+//  Copyright (c) 2015 Honza Dvorsky. All rights reserved.
+//
+
+import Foundation
+import BuildaCIServer
+import BuildaGitServer
+import BuildaUtils
+
+extension SyncPair {
+    
+    public struct Actions {
+        public let integrationsToCancel: [Integration]?
+        public let githubStatusToSet: (status: HDGitHubXCBotSyncer.GitHubStatusAndComment, pr: PullRequest)?
+        public let startNewIntegrationBot: Bot? //if non-nil, starts a new integration on this bot
+    }
+
+    func performActions(actions: Actions, completion: Completion) {
+        
+        let group = dispatch_group_create()
+        var lastGroupError: NSError?
+        
+        if let integrationsToCancel = actions.integrationsToCancel {
+            
+            dispatch_group_enter(group)
+            self.syncer.cancelIntegrations(integrationsToCancel, completion: { () -> () in
+                dispatch_group_leave(group)
+            })
+        }
+        
+        if let newStatus = actions.githubStatusToSet {
+            
+            let status = newStatus.status
+            let pr = newStatus.pr
+            
+            dispatch_group_enter(group)
+            self.syncer.updatePRStatusIfNecessary(status, prNumber: pr.number, completion: { (error) -> () in
+                if let error = error {
+                    lastGroupError = error
+                }
+                dispatch_group_leave(group)
+            })
+        }
+        
+        if let startNewIntegrationBot = actions.startNewIntegrationBot {
+            
+            let bot = startNewIntegrationBot
+            
+            dispatch_group_enter(group)
+            self.syncer.xcodeServer.postIntegration(bot.id, completion: { (integration, error) -> () in
+                
+                if let integration = integration where error == nil {
+                    Log.info("Bot \(bot.name) successfully enqueued Integration #\(integration.number)")
+                } else {
+                    let e = Error.withInfo("Bot \(bot.name) failed to enqueue an integration", internalError: error)
+                    lastGroupError = e
+                }
+                
+                dispatch_group_leave(group)
+            })
+        }
+        
+        dispatch_group_notify(group, dispatch_get_main_queue(), {
+            completion(error: lastGroupError)
+        })
+    }
+
+}

--- a/Buildasaur/SyncPairPRResolver.swift
+++ b/Buildasaur/SyncPairPRResolver.swift
@@ -1,0 +1,17 @@
+//
+//  SyncPairPRResolver.swift
+//  Buildasaur
+//
+//  Created by Honza Dvorsky on 19/05/15.
+//  Copyright (c) 2015 Honza Dvorsky. All rights reserved.
+//
+
+import Foundation
+import BuildaCIServer
+import BuildaGitServer
+import BuildaUtils
+
+public class SyncPairPRResolver: SyncPairResolver {
+    
+    
+}

--- a/Buildasaur/SyncPairResolver.swift
+++ b/Buildasaur/SyncPairResolver.swift
@@ -13,7 +13,11 @@ import BuildaUtils
 
 public class SyncPairResolver {
     
-    func resolveActionsForCommitAndIssueWithBotIntegrations(
+    public init() {
+        //
+    }
+    
+    public func resolveActionsForCommitAndIssueWithBotIntegrations(
         commit: String,
         issue: Issue?,
         bot: Bot,

--- a/Buildasaur/SyncPairResolver.swift
+++ b/Buildasaur/SyncPairResolver.swift
@@ -1,0 +1,317 @@
+//
+//  SyncPair_BotLogic.swift
+//  Buildasaur
+//
+//  Created by Honza Dvorsky on 19/05/15.
+//  Copyright (c) 2015 Honza Dvorsky. All rights reserved.
+//
+
+import Foundation
+import BuildaCIServer
+import BuildaGitServer
+import BuildaUtils
+
+public class SyncPairResolver {
+    
+    func resolveActionsForCommitAndIssueWithBotIntegrations(
+        commit: String,
+        issue: Issue?,
+        bot: Bot,
+        integrations: [Integration]) -> SyncPair.Actions {
+            
+            var integrationsToCancel: [Integration] = []
+            var startNewIntegration: Bool = false
+            
+            //------------
+            // Split integrations into two groups: 1) for this SHA, 2) the rest
+            //------------
+            
+            let uniqueIntegrations = Set(integrations)
+            
+            //1) for this SHA
+            let headCommitIntegrations = Set(self.headCommitIntegrationsFromAllIntegrations(commit, allIntegrations: integrations))
+            
+            //2) the rest
+            let otherCommitIntegrations = uniqueIntegrations.subtract(headCommitIntegrations)
+            let noncompletedOtherCommitIntegrations: Set<Integration> = otherCommitIntegrations.filterSet {
+                return $0.currentStep != .Completed
+            }
+            
+            //2.1) Ok, now first cancel all unfinished integrations of the non-current commits
+            integrationsToCancel += Array(noncompletedOtherCommitIntegrations)
+            
+            //------------
+            // Now we're resolving Integrations for the current commit only
+            //------------
+            /*
+            The resolving logic goes like this now. We have an array of integrations I for the latest commits.
+            A. is array empty?
+            A1. true -> there are no integrations for this commit. kick one off! we're done.
+            A2. false -> keep resolving (all references to "integrations" below mean only integrations of the current commit
+            B. take all pending integrations, keep the most recent one, if it's there, cancel all the other ones.
+            C. take the running integration, if it's there
+            D. take all completed integrations
+            
+            resolve the status of the PR as follows
+            
+            E. is there a latest pending integration?
+            E1. true -> status is ["Pending": "Waiting on the queue"]. also, if there's a running integration, cancel it.
+            E2. false ->
+            F. is there a running integration?
+            F1. true -> status is ["Pending": "Integration in progress..."]. update status and do nothing else.
+            F2. false ->
+            G. are there any completed integrations?
+            G1. true -> based on the result of the integrations create the PR status
+            G2. false -> this shouldn't happen, print a very angry message.
+            */
+            
+            //A. is this array empty?
+            if headCommitIntegrations.count == 0 {
+                
+                //A1. - it's empty, kick off an integration for the latest commit
+                return SyncPair.Actions(
+                    integrationsToCancel: integrationsToCancel,
+                    githubStatusToSet: nil,
+                    startNewIntegrationBot: bot
+                )
+            }
+            
+            //A2. not empty, keep resolving
+            
+            //B. get pending Integrations
+            let pending = headCommitIntegrations.filterSet {
+                $0.currentStep == .Pending
+            }
+            
+            var latestPendingIntegration: Integration?
+            if pending.count > 0 {
+                
+                //we should cancel all but the most recent one
+                //turn the pending set into an array and sort by integration number in ascending order
+                var pendingSortedArray: Array<Integration> = Array(pending).sorted({ (integrationA, integrationB) -> Bool in
+                    return integrationA.number < integrationB.number
+                })
+                
+                //keep the latest, which will be the last in the array
+                //let this one run, it might have been a force rebuild.
+                latestPendingIntegration = pendingSortedArray.removeLast()
+                
+                //however, cancel the rest of the pending integrations
+                integrationsToCancel += pendingSortedArray
+            }
+            
+            //Get the running integration, if it's there
+            let runningIntegration = headCommitIntegrations.filterSet {
+                $0.currentStep != .Completed && $0.currentStep != .Pending
+                }.first
+            
+            //Get all completed integrations for this commit
+            let completedIntegrations = headCommitIntegrations.filterSet {
+                $0.currentStep == .Completed
+            }
+            
+            //resolve to a status
+            let actions = self.resolveCommitStatusFromLatestIntegrations(
+                commit,
+                issue: issue,
+                pending: latestPendingIntegration,
+                running: runningIntegration,
+                completed: completedIntegrations)
+            
+            //merge in nested actions
+            return SyncPair.Actions(
+                integrationsToCancel: integrationsToCancel + (actions.integrationsToCancel ?? []),
+                githubStatusToSet: actions.githubStatusToSet,
+                startNewIntegrationBot: actions.startNewIntegrationBot ?? (startNewIntegration ? bot : nil)
+            )
+    }
+    
+    func headCommitIntegrationsFromAllIntegrations(headCommit: String, allIntegrations: [Integration]) -> [Integration] {
+        
+        let uniqueIntegrations = Set(allIntegrations)
+        
+        //1) for this SHA
+        let headCommitIntegrations = uniqueIntegrations.filterSet {
+            (integration: Integration) -> Bool in
+            
+            //if it's not pending, we need to take a look at the blueprint and inspect the SHA.
+            if let blueprint = integration.blueprint, let sha = blueprint.commitSHA {
+                return sha == headCommit
+            }
+            
+            //when an integration is Pending, Preparing or Checking out, it doesn't have a blueprint, but it is, by definition, a headCommit
+            //integration (because it will check out the latest commit on the branch when it starts running)
+            if
+                integration.currentStep == .Pending ||
+                    integration.currentStep == .Preparing ||
+                    integration.currentStep == .Checkout
+            {
+                return true
+            }
+            
+            if integration.currentStep == .Completed {
+                
+                if let result = integration.result {
+                    
+                    //if the result doesn't have a SHA yet and isn't pending - take a look at the result
+                    //if it's a checkout-error, assume that it is a malformed SSH key bot, so don't keep
+                    //restarting integrations - at least until someone fixes it (by closing the PR and fixing
+                    //their SSH keys in Buildasaur so that when the next bot gets created, it does so with the right
+                    //SSH keys.
+                    if result == .CheckoutError {
+                        Log.error("Integration #\(integration.number) finished with a checkout error - please check that your SSH keys setup in Buildasaur are correct! If you need to fix them, please do so and then you need to recreate the bot - e.g. by closing the Pull Request, waiting for a sync (bot will disappear) and then reopening the Pull Request - should do the job!")
+                        return true
+                    }
+                    
+                    if result == .Canceled {
+                        
+                        //another case is when the integration gets doesn't yet have a blueprint AND was cancelled -
+                        //we should assume it belongs to the latest commit, because we can't tell otherwise.
+                        return true
+                    }
+                }
+            }
+            
+            return false
+        }
+        
+        let sortedHeadCommitIntegrations = sorted(Array(headCommitIntegrations), {
+            (a: Integration, b: Integration) -> Bool in
+            return a.number > b.number
+        })
+        return sortedHeadCommitIntegrations
+    }
+    
+    func resolveCommitStatusFromLatestIntegrations(
+        commit: String,
+        issue: Issue?,
+        pending: Integration?,
+        running: Integration?,
+        completed: Set<Integration>) -> SyncPair.Actions {
+            
+            let statusWithComment: HDGitHubXCBotSyncer.GitHubStatusAndComment
+            var integrationsToCancel: [Integration] = []
+            
+            //if there's any pending integration, we're ["Pending" - Waiting in the queue]
+            if let pending = pending {
+                
+                //TODO: show how many builds are ahead in the queue and estimate when it will be
+                //started and when finished? (there is an average running time on each bot, it should be easy)
+                let status = HDGitHubXCBotSyncer.createStatusFromState(.Pending, description: "Build waiting in the queue...")
+                statusWithComment = (status: status, comment: nil)
+                
+                //also, cancel the running integration, if it's there any
+                if let running = running {
+                    integrationsToCancel.append(running)
+                }
+            } else {
+                
+                //there's no pending integration, it's down to running and completed
+                if let running = running {
+                    
+                    //there is a running integration.
+                    //TODO: estimate, based on the average running time of this bot and on the started timestamp, when it will finish. add that to the description.
+                    let currentStepString = running.currentStep.rawValue
+                    let status = HDGitHubXCBotSyncer.createStatusFromState(.Pending, description: "Integration step: \(currentStepString)...")
+                    statusWithComment = (status: status, comment: nil)
+                    
+                } else {
+                    
+                    //there no running integration, we're down to completed integration.
+                    if completed.count > 0 {
+                        
+                        //we have some completed integrations
+                        statusWithComment = self.resolveStatusFromCompletedIntegrations(completed)
+                        
+                    } else {
+                        //this shouldn't happen.
+                        Log.error("LOGIC ERROR! This shouldn't happen, there are no completed integrations!")
+                        let status = HDGitHubXCBotSyncer.createStatusFromState(.Error, description: "* UNKNOWN STATE, Builda ERROR *")
+                        statusWithComment = (status: status, "Builda error, unknown state!")
+                    }
+                }
+            }
+            
+            return SyncPair.Actions(
+                integrationsToCancel: integrationsToCancel,
+                githubStatusToSet: (status: statusWithComment, commit: commit, issue: issue),
+                startNewIntegrationBot: nil
+            )
+    }
+    
+    func resolveStatusFromCompletedIntegrations(
+        integrations: Set<Integration>) -> HDGitHubXCBotSyncer.GitHubStatusAndComment {
+            
+            //get integrations sorted by number
+            let sortedDesc = Array(integrations).sorted { $0.number > $1.number }
+            
+            //if there are any succeeded, it wins - iterating from the end
+            if let passingIntegration = sortedDesc.filter({
+                (integration: Integration) -> Bool in
+                switch integration.result! {
+                case Integration.Result.Succeeded, Integration.Result.Warnings, Integration.Result.AnalyzerWarnings:
+                    return true
+                default:
+                    return false
+                }
+            }).first {
+                
+                let baseComment = HDGitHubXCBotSyncer.baseCommentFromIntegration(passingIntegration)
+                let comment: String
+                let status = HDGitHubXCBotSyncer.createStatusFromState(.Success, description: "Build passed!")
+                let summary = passingIntegration.buildResultSummary!
+                if passingIntegration.result == .Succeeded {
+                    comment = baseComment + "Perfect build! All \(summary.testsCount) tests passed. :+1:"
+                } else if passingIntegration.result == .Warnings {
+                    comment = baseComment + "All \(summary.testsCount) tests passed, but please fix \(summary.warningCount) warnings."
+                } else {
+                    comment = baseComment + "All \(summary.testsCount) tests passed, but please fix \(summary.analyzerWarningCount) analyzer warnings."
+                }
+                return (status: status, comment: comment)
+            }
+            
+            //ok, no succeeded, warnings or analyzer warnings, get down to test failures
+            if let testFailingIntegration = sortedDesc.filter({
+                $0.result! == Integration.Result.TestFailures
+            }).first {
+                
+                let baseComment = HDGitHubXCBotSyncer.baseCommentFromIntegration(testFailingIntegration)
+                let status = HDGitHubXCBotSyncer.createStatusFromState(.Failure, description: "Build failed tests!")
+                let summary = testFailingIntegration.buildResultSummary!
+                let comment = baseComment + "Build failed \(summary.testFailureCount) tests out of \(summary.testsCount)"
+                return (status: status, comment: comment)
+            }
+            
+            //ok, the build didn't even run then. it either got cancelled or failed
+            if let erroredIntegration = sortedDesc.filter({
+                $0.result! != Integration.Result.Canceled
+            }).first {
+                
+                let baseComment = HDGitHubXCBotSyncer.baseCommentFromIntegration(erroredIntegration)
+                let errorCount: String
+                if let summary = erroredIntegration.buildResultSummary {
+                    errorCount = "\(summary.errorCount)"
+                } else {
+                    errorCount = "?"
+                }
+                let status = HDGitHubXCBotSyncer.createStatusFromState(.Error, description: "Build error!")
+                let comment = baseComment + "\(errorCount) build errors: \(erroredIntegration.result!.rawValue)"
+                return (status: status, comment: comment)
+            }
+            
+            //cool, not even build error. it must be just canceled ones then.
+            if let canceledIntegration = sortedDesc.filter({
+                $0.result! == Integration.Result.Canceled
+            }).first {
+                
+                let baseComment = HDGitHubXCBotSyncer.baseCommentFromIntegration(canceledIntegration)
+                let status = HDGitHubXCBotSyncer.createStatusFromState(.Error, description: "Build canceled!")
+                let comment = baseComment + "Build was manually canceled."
+                return (status: status, comment: comment)
+            }
+            
+            //hmm no idea, if we got all the way here. just leave it with no state.
+            let status = HDGitHubXCBotSyncer.createStatusFromState(.NoState, description: nil)
+            return (status: status, comment: nil)
+    }
+}

--- a/Buildasaur/SyncPair_Branch_Bot.swift
+++ b/Buildasaur/SyncPair_Branch_Bot.swift
@@ -1,0 +1,33 @@
+//
+//  SyncPair_Branch_Bot.swift
+//  Buildasaur
+//
+//  Created by Honza Dvorsky on 19/05/15.
+//  Copyright (c) 2015 Honza Dvorsky. All rights reserved.
+//
+
+import Foundation
+import BuildaCIServer
+import BuildaGitServer
+import BuildaUtils
+
+public class SyncPair_Branch_Bot: SyncPair {
+    
+    let branch: Branch
+    let bot: Bot
+    
+    public init(branch: Branch, bot: Bot) {
+        self.branch = branch
+        self.bot = bot
+        super.init()
+    }
+    
+    override func sync(completion: Completion) {
+        
+        //sync the branch with the bot
+    }
+    
+    override func syncPairName() -> String {
+        return "Branch (\(self.branch.name)) + Bot (\(self.bot.name))"
+    }
+}

--- a/Buildasaur/SyncPair_Branch_Bot.swift
+++ b/Buildasaur/SyncPair_Branch_Bot.swift
@@ -15,19 +15,52 @@ public class SyncPair_Branch_Bot: SyncPair {
     
     let branch: Branch
     let bot: Bot
+    let resolver: SyncPairBranchResolver
     
-    public init(branch: Branch, bot: Bot) {
+    public init(branch: Branch, bot: Bot, resolver: SyncPairBranchResolver) {
         self.branch = branch
         self.bot = bot
+        self.resolver = resolver
         super.init()
     }
     
     override func sync(completion: Completion) {
         
         //sync the branch with the bot
+        self.syncBranchWithBot(completion)
     }
     
     override func syncPairName() -> String {
         return "Branch (\(self.branch.name)) + Bot (\(self.bot.name))"
+    }
+    
+    //MARK: Internal
+    
+    private func syncBranchWithBot(completion: Completion) {
+        
+        let syncer = self.syncer
+        let bot = self.bot
+        let headCommit = self.branch.commit.sha
+        let issue: Issue? = nil //TODO: only pull/create if we're failing
+        
+        self.getIntegrations(bot, completion: { (integrations, error) -> () in
+            
+            if let error = error {
+                completion(error: error)
+                return
+            }
+            
+            let actions = self.resolver.resolveActionsForCommitAndIssueWithBotIntegrations(
+                headCommit,
+                issue: issue,
+                bot: bot,
+                integrations: integrations)
+            
+            //in case of branches, we also (optionally) want to add functionality for creating an issue if the branch starts failing and updating with comments the same way we do with PRs.
+            //also, when the build is finally successful on the branch, the issue will be automatically closed.
+            //TODO: add this functionality here and add it as another action available from a sync pair
+            
+            self.performActions(actions, completion: completion)
+        })
     }
 }

--- a/Buildasaur/SyncPair_Branch_NoBot.swift
+++ b/Buildasaur/SyncPair_Branch_NoBot.swift
@@ -1,0 +1,46 @@
+//
+//  SyncPair_Branch_NoBot.swift
+//  Buildasaur
+//
+//  Created by Honza Dvorsky on 20/05/15.
+//  Copyright (c) 2015 Honza Dvorsky. All rights reserved.
+//
+
+import Foundation
+import BuildaCIServer
+import BuildaGitServer
+
+class SyncPair_Branch_NoBot: SyncPair {
+    
+    let branch: Branch
+    let repo: Repo
+    
+    init(branch: Branch, repo: Repo) {
+        self.branch = branch
+        self.repo = repo
+        super.init()
+    }
+    
+    override func sync(completion: Completion) {
+        
+        //create a bot for this branch
+        let syncer = self.syncer
+        let branch = self.branch
+        let repo = self.repo
+        
+        SyncPair_Branch_NoBot.createBotForBranch(syncer: syncer, branch: branch, repo: repo, completion: completion)
+    }
+    
+    override func syncPairName() -> String {
+        return "Branch (\(self.branch.name)) + No Bot"
+    }
+    
+    //MARK: Internal
+    
+    private class func createBotForBranch(#syncer: HDGitHubXCBotSyncer, branch: Branch, repo: Repo, completion: Completion) {
+        
+        syncer.createBotFromBranch(branch, repo: repo, completion: { () -> () in
+            completion(error: nil)
+        })
+    }
+}

--- a/Buildasaur/SyncPair_Deletable_Bot.swift
+++ b/Buildasaur/SyncPair_Deletable_Bot.swift
@@ -1,5 +1,5 @@
 //
-//  SyncPair_NoPR_Bot.swift
+//  SyncPair_Deletable_Bot.swift
 //  Buildasaur
 //
 //  Created by Honza Dvorsky on 16/05/2015.
@@ -10,7 +10,7 @@ import Foundation
 import BuildaCIServer
 import BuildaGitServer
 
-class SyncPair_NoPR_Bot: SyncPair {
+class SyncPair_Deletable_Bot: SyncPair {
     
     let bot: Bot
     
@@ -25,11 +25,11 @@ class SyncPair_NoPR_Bot: SyncPair {
         let syncer = self.syncer
         let bot = self.bot
         
-        SyncPair_NoPR_Bot.deleteBot(syncer: syncer, bot: bot, completion: completion)
+        SyncPair_Deletable_Bot.deleteBot(syncer: syncer, bot: bot, completion: completion)
     }
     
     override func syncPairName() -> String {
-        return "No PR + Bot (\(self.bot.name))"
+        return "Deletable Bot (\(self.bot.name))"
     }
     
     private class func deleteBot(#syncer: HDGitHubXCBotSyncer, bot: Bot, completion: Completion) {

--- a/Buildasaur/SyncPair_PR_Bot.swift
+++ b/Buildasaur/SyncPair_PR_Bot.swift
@@ -15,7 +15,7 @@ public class SyncPair_PR_Bot: SyncPair {
     
     let pr: PullRequest
     let bot: Bot
-    let resolver: SyncPairPRResolver
+    public let resolver: SyncPairPRResolver
     
     public init(pr: PullRequest, bot: Bot, resolver: SyncPairPRResolver) {
         self.pr = pr

--- a/Buildasaur/SyncPair_PR_Bot.swift
+++ b/Buildasaur/SyncPair_PR_Bot.swift
@@ -13,13 +13,14 @@ import BuildaUtils
 
 public class SyncPair_PR_Bot: SyncPair {
     
-    
     let pr: PullRequest
     let bot: Bot
+    let resolver: SyncPairPRResolver
     
-    public init(pr: PullRequest, bot: Bot) {
+    public init(pr: PullRequest, bot: Bot, resolver: SyncPairPRResolver) {
         self.pr = pr
         self.bot = bot
+        self.resolver = resolver
         super.init()
     }
     
@@ -38,73 +39,56 @@ public class SyncPair_PR_Bot: SyncPair {
     private func syncPRWithBot(completion: Completion) {
         
         let syncer = self.syncer
-        let pr = self.pr
         let bot = self.bot
-        
-        /*
-        TODO: we should establish some reliable and reasonable plan for how many integrations to fetch.
-        currently it's always 20, but some setups might have a crazy workflow with very frequent commits
-        on active bots etc.
-        */
-        let query = [
-            "last": "20"
-        ]
-        syncer.xcodeServer.getIntegrations(bot.id, query: query, completion: { (integrations, error) -> () in
+        let pr = self.pr
+        let headCommit = pr.head.sha
+        let issue = pr
+
+        self.getIntegrations(bot, completion: { (integrations, error) -> () in
             
             if let error = error {
-                let e = Error.withInfo("Bot \(bot.name) failed return integrations", internalError: error)
-                completion(error: e)
+                completion(error: error)
                 return
             }
             
-            if let integrations = integrations {
+            //first check whether the bot is even enabled
+            self.isBotEnabled(integrations: integrations, completion: { (isEnabled, error) -> () in
                 
-                //first check whether the bot is even enabled
-                SyncPair_PR_Bot.isBotEnabled(syncer, pr: pr, integrations: integrations, completion: { (isEnabled, error) -> () in
+                if let error = error {
+                    completion(error: error)
+                    return
+                }
+                
+                if isEnabled {
                     
-                    if let error = error {
-                        completion(error: error)
-                        return
-                    }
+                    let actions = self.resolver.resolveActionsForCommitAndIssueWithBotIntegrations(
+                        headCommit,
+                        issue: issue,
+                        bot: bot,
+                        integrations: integrations)
+                    self.performActions(actions, completion: completion)
                     
-                    if isEnabled {
-                        
-                        let actions = SyncPair_PR_Bot.syncPRWithBotIntegrations(
-                            pr: pr,
-                            bot: bot,
-                            integrations: integrations)
-                        self.performActions(actions, completion: completion)
-                        
-                    } else {
-                        
-                        //not enabled, make sure the PR reflects that and the instructions are clear
-                        Log.verbose("Bot \(bot.name) is not yet enabled, ignoring...")
-                        
-                        let status = HDGitHubXCBotSyncer.createStatusFromState(.Pending, description: "Waiting for \"lttm\" to start testing")
-                        let notYetEnabled: HDGitHubXCBotSyncer.GitHubStatusAndComment = (status: status, comment: nil)
-                        syncer.updatePRStatusIfNecessary(notYetEnabled, prNumber: pr.number, completion: completion)
-                    }
-                })
-            } else {
-                let e = Error.withInfo("Getting integrations", internalError: Error.withInfo("Nil integrations even after returning nil error!"))
-                completion(error: e)
-            }
+                } else {
+                    
+                    //not enabled, make sure the PR reflects that and the instructions are clear
+                    Log.verbose("Bot \(bot.name) is not yet enabled, ignoring...")
+                    
+                    let status = HDGitHubXCBotSyncer.createStatusFromState(.Pending, description: "Waiting for \"lttm\" to start testing")
+                    let notYetEnabled: HDGitHubXCBotSyncer.GitHubStatusAndComment = (status: status, comment: nil)
+                    syncer.updateCommitStatusIfNecessary(notYetEnabled, commit: headCommit, issue: pr, completion: completion)
+                }
+            })
         })
     }
     
-    private class func isBotEnabled(
-        syncer: HDGitHubXCBotSyncer,
-        pr: PullRequest,
-        integrations: [Integration],
-        completion: (isEnabled: Bool, error: NSError?) -> ()
-        ) {
+    private func isBotEnabled(#integrations: [Integration], completion: (isEnabled: Bool, error: NSError?) -> ()) {
         
         //bot is enabled if (there are any integrations) OR (there is a recent comment with a keyword to enable the bot in the pull request's conversation)
         //which means that there are two ways of enabling a bot.
         //a) manually start an integration through Xcode, API call or in Builda's GUI (TBB)
         //b) (optional) comment an agreed keyword in the Pull Request, e.g. "lttm" - 'looks testable to me' is a frequent one
         
-        if integrations.count > 0 || !syncer.waitForLttm {
+        if integrations.count > 0 || !self.syncer.waitForLttm {
             completion(isEnabled: true, error: nil)
             return
         }
@@ -113,7 +97,7 @@ public class SyncPair_PR_Bot: SyncPair {
         
         if let repoName = syncer.repoName() {
             
-            syncer.github.findMatchingCommentInIssue(keyword, issue: pr.number, repo: repoName) {
+            self.syncer.github.findMatchingCommentInIssue(keyword, issue: self.pr.number, repo: repoName) {
                 (foundComments, error) -> () in
                 
                 if error != nil {
@@ -132,298 +116,6 @@ public class SyncPair_PR_Bot: SyncPair {
         } else {
             completion(isEnabled: false, error: Error.withInfo("No repo name, cannot find the GitHub repo!"))
         }
-    }
-    
-    public class func syncPRWithBotIntegrations(
-        #pr: PullRequest,
-        bot: Bot,
-        integrations: [Integration]
-        ) -> Actions {
-            
-            var integrationsToCancel: [Integration] = []
-            var startNewIntegration: Bool = false
-            
-            let uniqueIntegrations = Set(integrations)
-            
-            //------------
-            // Split integrations into two groups: 1) for this SHA, 2) the rest
-            //------------
-            
-            let headCommit: String = pr.head.sha
-            
-            //1) for this SHA
-            let headCommitIntegrations = uniqueIntegrations.filterSet {
-                (integration: Integration) -> Bool in
-                
-                //if it's not pending, we need to take a look at the blueprint and inspect the SHA.
-                if let blueprint = integration.blueprint, let sha = blueprint.commitSHA {
-                    return sha == headCommit
-                }
-                
-                //when an integration is Pending, Preparing or Checking out, it doesn't have a blueprint, but it is, by definition, a headCommit
-                //integration (because it will check out the latest commit on the branch when it starts running)
-                if
-                    integration.currentStep == .Pending ||
-                        integration.currentStep == .Preparing ||
-                        integration.currentStep == .Checkout
-                {
-                    return true
-                }
-                
-                if integration.currentStep == .Completed {
-                    
-                    if let result = integration.result {
-                        
-                        //if the result doesn't have a SHA yet and isn't pending - take a look at the result
-                        //if it's a checkout-error, assume that it is a malformed SSH key bot, so don't keep
-                        //restarting integrations - at least until someone fixes it (by closing the PR and fixing
-                        //their SSH keys in Buildasaur so that when the next bot gets created, it does so with the right
-                        //SSH keys.
-                        if result == .CheckoutError {
-                            Log.error("Integration #\(integration.number) finished with a checkout error - please check that your SSH keys setup in Buildasaur are correct! If you need to fix them, please do so and then you need to recreate the bot - e.g. by closing the Pull Request, waiting for a sync (bot will disappear) and then reopening the Pull Request - should do the job!")
-                            return true
-                        }
-                        
-                        if result == .Canceled {
-                            
-                            //another case is when the integration gets doesn't yet have a blueprint AND was cancelled -
-                            //we should assume it belongs to the latest commit, because we can't tell otherwise.
-                            return true
-                        }
-                    }
-                }
-                
-                return false
-            }
-            
-            //2) the rest
-            let otherCommitIntegrations = uniqueIntegrations.subtract(headCommitIntegrations)
-            let noncompletedOtherCommitIntegrations: Set<Integration> = otherCommitIntegrations.filterSet {
-                return $0.currentStep != .Completed
-            }
-            
-            //2.1) Ok, now first cancel all unfinished integrations of the non-current commits
-            integrationsToCancel += Array(noncompletedOtherCommitIntegrations)
-            
-            //------------
-            // Now we're resolving Integrations for the current commit only
-            //------------
-            /*
-            The resolving logic goes like this now. We have an array of integrations I for the latest commits.
-            A. is array empty?
-            A1. true -> there are no integrations for this commit. kick one off! we're done.
-            A2. false -> keep resolving (all references to "integrations" below mean only integrations of the current commit
-            B. take all pending integrations, keep the most recent one, if it's there, cancel all the other ones.
-            C. take the running integration, if it's there
-            D. take all completed integrations
-            
-            resolve the status of the PR as follows
-            
-            E. is there a latest pending integration?
-            E1. true -> status is ["Pending": "Waiting on the queue"]. also, if there's a running integration, cancel it.
-            E2. false ->
-            F. is there a running integration?
-            F1. true -> status is ["Pending": "Integration in progress..."]. update status and do nothing else.
-            F2. false ->
-            G. are there any completed integrations?
-            G1. true -> based on the result of the integrations create the PR status
-            G2. false -> this shouldn't happen, print a very angry message.
-            */
-            
-            //A. is this array empty?
-            if headCommitIntegrations.count == 0 {
-                
-                //A1. - it's empty, kick off an integration for the latest commit
-                return Actions(
-                    integrationsToCancel: integrationsToCancel,
-                    githubStatusToSet: nil,
-                    startNewIntegrationBot: bot
-                )
-            }
-            
-            //A2. not empty, keep resolving
-            
-            //B. get pending Integrations
-            let pending = headCommitIntegrations.filterSet {
-                $0.currentStep == .Pending
-            }
-            
-            var latestPendingIntegration: Integration?
-            if pending.count > 0 {
-                
-                //we should cancel all but the most recent one
-                //turn the pending set into an array and sort by integration number in ascending order
-                var pendingSortedArray: Array<Integration> = Array(pending).sorted({ (integrationA, integrationB) -> Bool in
-                    return integrationA.number < integrationB.number
-                })
-                
-                //keep the latest, which will be the last in the array
-                //let this one run, it might have been a force rebuild.
-                latestPendingIntegration = pendingSortedArray.removeLast()
-                
-                //however, cancel the rest of the pending integrations
-                integrationsToCancel += pendingSortedArray
-            }
-            
-            //Get the running integration, if it's there
-            let runningIntegration = headCommitIntegrations.filterSet {
-                $0.currentStep != .Completed && $0.currentStep != .Pending
-                }.first
-            
-            //Get all completed integrations for this commit
-            let completedIntegrations = headCommitIntegrations.filterSet {
-                $0.currentStep == .Completed
-            }
-            
-            //resolve to a status
-            let actions = self.resolvePRStatusFromLatestIntegrations(
-                pr: pr,
-                pending: latestPendingIntegration,
-                running: runningIntegration,
-                completed: completedIntegrations)
-            
-            //merge in nested actions
-            return Actions(
-                integrationsToCancel: integrationsToCancel + (actions.integrationsToCancel ?? []),
-                githubStatusToSet: actions.githubStatusToSet,
-                startNewIntegrationBot: actions.startNewIntegrationBot ?? (startNewIntegration ? bot : nil)
-            )
-    }
-    
-    //MARK: Pure Logic
-    
-    private class func resolvePRStatusFromLatestIntegrations(
-        #pr: PullRequest,
-        pending: Integration?,
-        running: Integration?,
-        completed: Set<Integration>
-        ) -> Actions {
-        
-        let statusWithComment: HDGitHubXCBotSyncer.GitHubStatusAndComment
-        var integrationsToCancel: [Integration] = []
-        
-        //if there's any pending integration, we're ["Pending" - Waiting in the queue]
-        if let pending = pending {
-            
-            //TODO: show how many builds are ahead in the queue and estimate when it will be
-            //started and when finished? (there is an average running time on each bot, it should be easy)
-            let status = HDGitHubXCBotSyncer.createStatusFromState(.Pending, description: "Build waiting in the queue...")
-            statusWithComment = (status: status, comment: nil)
-            
-            //also, cancel the running integration, if it's there any
-            if let running = running {
-                integrationsToCancel.append(running)
-            }
-        } else {
-            
-            //there's no pending integration, it's down to running and completed
-            if let running = running {
-                
-                //there is a running integration.
-                //TODO: estimate, based on the average running time of this bot and on the started timestamp, when it will finish. add that to the description.
-                let currentStepString = running.currentStep.rawValue
-                let status = HDGitHubXCBotSyncer.createStatusFromState(.Pending, description: "Integration step: \(currentStepString)...")
-                statusWithComment = (status: status, comment: nil)
-                
-            } else {
-                
-                //there no running integration, we're down to completed integration.
-                if completed.count > 0 {
-                    
-                    //we have some completed integrations
-                    statusWithComment = self.resolveStatusFromCompletedIntegrations(integrations: completed)
-                    
-                } else {
-                    //this shouldn't happen.
-                    Log.error("LOGIC ERROR! This shouldn't happen, there are no completed integrations!")
-                    let status = HDGitHubXCBotSyncer.createStatusFromState(.Error, description: "* UNKNOWN STATE, Builda ERROR *")
-                    statusWithComment = (status: status, "Builda error, unknown state!")
-                }
-            }
-        }
-        
-        return Actions(
-            integrationsToCancel: integrationsToCancel,
-            githubStatusToSet: (status: statusWithComment, pr: pr),
-            startNewIntegrationBot: nil
-        )
-    }
-    
-    private class func resolveStatusFromCompletedIntegrations(
-        #integrations: Set<Integration>
-        ) -> HDGitHubXCBotSyncer.GitHubStatusAndComment {
-        
-        //get integrations sorted by number
-        let sortedDesc = Array(integrations).sorted { $0.number > $1.number }
-        
-        //if there are any succeeded, it wins - iterating from the end
-        if let passingIntegration = sortedDesc.filter({
-            (integration: Integration) -> Bool in
-            switch integration.result! {
-            case Integration.Result.Succeeded, Integration.Result.Warnings, Integration.Result.AnalyzerWarnings:
-                return true
-            default:
-                return false
-            }
-        }).first {
-            
-            let baseComment = HDGitHubXCBotSyncer.baseCommentFromIntegration(passingIntegration)
-            let comment: String
-            let status = HDGitHubXCBotSyncer.createStatusFromState(.Success, description: "Build passed!")
-            let summary = passingIntegration.buildResultSummary!
-            if passingIntegration.result == .Succeeded {
-                comment = baseComment + "Perfect build! All \(summary.testsCount) tests passed. :+1:"
-            } else if passingIntegration.result == .Warnings {
-                comment = baseComment + "All \(summary.testsCount) tests passed, but please fix \(summary.warningCount) warnings."
-            } else {
-                comment = baseComment + "All \(summary.testsCount) tests passed, but please fix \(summary.analyzerWarningCount) analyzer warnings."
-            }
-            return (status: status, comment: comment)
-        }
-        
-        //ok, no succeeded, warnings or analyzer warnings, get down to test failures
-        if let testFailingIntegration = sortedDesc.filter({
-            $0.result! == Integration.Result.TestFailures
-        }).first {
-            
-            let baseComment = HDGitHubXCBotSyncer.baseCommentFromIntegration(testFailingIntegration)
-            let status = HDGitHubXCBotSyncer.createStatusFromState(.Failure, description: "Build failed tests!")
-            let summary = testFailingIntegration.buildResultSummary!
-            let comment = baseComment + "Build failed \(summary.testFailureCount) tests out of \(summary.testsCount)"
-            return (status: status, comment: comment)
-        }
-        
-        //ok, the build didn't even run then. it either got cancelled or failed
-        if let erroredIntegration = sortedDesc.filter({
-            $0.result! != Integration.Result.Canceled
-        }).first {
-            
-            let baseComment = HDGitHubXCBotSyncer.baseCommentFromIntegration(erroredIntegration)
-            let errorCount: String
-            if let summary = erroredIntegration.buildResultSummary {
-                errorCount = "\(summary.errorCount)"
-            } else {
-                errorCount = "?"
-            }
-            let status = HDGitHubXCBotSyncer.createStatusFromState(.Error, description: "Build error!")
-            let comment = baseComment + "\(errorCount) build errors: \(erroredIntegration.result!.rawValue)"
-            return (status: status, comment: comment)
-        }
-        
-        //cool, not even build error. it must be just canceled ones then.
-        if let canceledIntegration = sortedDesc.filter({
-            $0.result! == Integration.Result.Canceled
-        }).first {
-            
-            let baseComment = HDGitHubXCBotSyncer.baseCommentFromIntegration(canceledIntegration)
-            let status = HDGitHubXCBotSyncer.createStatusFromState(.Error, description: "Build canceled!")
-            let comment = baseComment + "Build was manually canceled."
-            return (status: status, comment: comment)
-        }
-        
-        //hmm no idea, if we got all the way here. just leave it with no state.
-        let status = HDGitHubXCBotSyncer.createStatusFromState(.NoState, description: nil)
-        return (status: status, comment: nil)
     }
 }
 

--- a/Buildasaur/SyncPair_PR_NoBot.swift
+++ b/Buildasaur/SyncPair_PR_NoBot.swift
@@ -40,5 +40,4 @@ class SyncPair_PR_NoBot: SyncPair {
             completion(error: nil)
         })
     }
-    
 }

--- a/Buildasaur/SyncerBotNaming.swift
+++ b/Buildasaur/SyncerBotNaming.swift
@@ -20,6 +20,10 @@ class BotNaming {
         return bot.name.hasPrefix(self.prefixForBuildaBotInRepoWithName(repoName))
     }
     
+    class func nameForBotWithBranch(branch: Branch, repoName: String) -> String {
+        return "\(self.prefixForBuildaBotInRepoWithName(repoName)) |-> \(branch.name)"
+    }
+    
     class func nameForBotWithPR(pr: PullRequest, repoName: String) -> String {
         return "\(self.prefixForBuildaBotInRepoWithName(repoName)) PR #\(pr.number)"
     }

--- a/BuildasaurTests/Mocks.swift
+++ b/BuildasaurTests/Mocks.swift
@@ -52,6 +52,26 @@ class MockRepo: Repo {
     }
 }
 
+class MockBranch: Branch {
+    
+    class func mockDictionary(name: String = "master", sha: String = "1234f") -> NSDictionary {
+        return [
+            "name": name,
+            "commit": [
+                "sha": sha
+            ]
+        ]
+    }
+    
+    convenience init(name: String = "master", sha: String = "1234f") {
+        self.init(json: MockBranch.mockDictionary(name: name, sha: sha))
+    }
+    
+    required init(json: NSDictionary) {
+        super.init(json: json)
+    }
+}
+
 class MockPullRequestBranch: PullRequestBranch {
     
     class func mockDictionary(ref: String = "mock_ref", sha: String = "1234f") -> NSDictionary {

--- a/BuildasaurTests/SyncPair_PR_Bot_Tests.swift
+++ b/BuildasaurTests/SyncPair_PR_Bot_Tests.swift
@@ -42,8 +42,7 @@ class SyncPair_PR_Bot_Tests: XCTestCase {
         let actions = SyncPair_PR_Bot.syncPRWithBotIntegrations(pr: pr, bot: bot, integrations: integrations)
         XCTAssertEqual(actions.integrationsToCancel?.count ?? 0, 0)
         XCTBAssertNil(actions.githubStatusToSet)
-        XCTAssertNotNil(actions.startNewIntegration)
-        XCTAssertTrue(actions.startNewIntegration!)
+        XCTAssertNotNil(actions.startNewIntegrationBot)
     }
     
     func testFirstIntegrationPending() {
@@ -55,9 +54,9 @@ class SyncPair_PR_Bot_Tests: XCTestCase {
         
         let actions = SyncPair_PR_Bot.syncPRWithBotIntegrations(pr: pr, bot: bot, integrations: integrations)
         XCTAssertEqual(actions.integrationsToCancel?.count ?? 0, 0)
-        XCTAssertFalse(actions.startNewIntegration ?? true)
+        XCTAssertNil(actions.startNewIntegrationBot)
         XCTBAssertNotNil(actions.githubStatusToSet)
-        XCTAssertEqual(actions.githubStatusToSet!.status.state, Status.State.Pending)
+        XCTAssertEqual(actions.githubStatusToSet!.status.status.state, Status.State.Pending)
     }
     
     func testMultipleIntegrationsPending() {
@@ -76,9 +75,9 @@ class SyncPair_PR_Bot_Tests: XCTestCase {
         XCTAssertEqual(toCancel.count, 2)
         XCTAssertTrue(toCancel.contains(integrations[0]))
         XCTAssertTrue(toCancel.contains(integrations[1]))
-        XCTAssertFalse(actions.startNewIntegration ?? true)
+        XCTAssertNil(actions.startNewIntegrationBot)
         XCTBAssertNotNil(actions.githubStatusToSet)
-        XCTAssertEqual(actions.githubStatusToSet!.status.state, Status.State.Pending)
+        XCTAssertEqual(actions.githubStatusToSet!.status.status.state, Status.State.Pending)
     }
     
     func testOneIntegrationRunning() {
@@ -91,9 +90,9 @@ class SyncPair_PR_Bot_Tests: XCTestCase {
         let actions = SyncPair_PR_Bot.syncPRWithBotIntegrations(pr: pr, bot: bot, integrations: integrations)
         
         XCTAssertEqual(actions.integrationsToCancel!.count, 0)
-        XCTAssertFalse(actions.startNewIntegration ?? true)
+        XCTAssertNil(actions.startNewIntegrationBot)
         XCTBAssertNotNil(actions.githubStatusToSet)
-        XCTAssertEqual(actions.githubStatusToSet!.status.state, Status.State.Pending)
+        XCTAssertEqual(actions.githubStatusToSet!.status.status.state, Status.State.Pending)
     }
     
     func testOneIntegrationTestsFailed() {
@@ -106,9 +105,9 @@ class SyncPair_PR_Bot_Tests: XCTestCase {
         let actions = SyncPair_PR_Bot.syncPRWithBotIntegrations(pr: pr, bot: bot, integrations: integrations)
         
         XCTAssertEqual(actions.integrationsToCancel!.count, 0)
-        XCTAssertFalse(actions.startNewIntegration ?? true)
+        XCTAssertNil(actions.startNewIntegrationBot)
         XCTBAssertNotNil(actions.githubStatusToSet)
-        XCTAssertEqual(actions.githubStatusToSet!.status.state, Status.State.Failure)
+        XCTAssertEqual(actions.githubStatusToSet!.status.status.state, Status.State.Failure)
     }
     
     func testOneIntegrationSuccess() {
@@ -121,9 +120,9 @@ class SyncPair_PR_Bot_Tests: XCTestCase {
         let actions = SyncPair_PR_Bot.syncPRWithBotIntegrations(pr: pr, bot: bot, integrations: integrations)
         
         XCTAssertEqual(actions.integrationsToCancel!.count, 0)
-        XCTAssertFalse(actions.startNewIntegration ?? true)
+        XCTAssertNil(actions.startNewIntegrationBot)
         XCTBAssertNotNil(actions.githubStatusToSet)
-        XCTAssertEqual(actions.githubStatusToSet!.status.state, Status.State.Success)
+        XCTAssertEqual(actions.githubStatusToSet!.status.status.state, Status.State.Success)
     }
     
     func testTwoIntegrationOneRunningOnePending() {
@@ -137,9 +136,9 @@ class SyncPair_PR_Bot_Tests: XCTestCase {
         let actions = SyncPair_PR_Bot.syncPRWithBotIntegrations(pr: pr, bot: bot, integrations: integrations)
         
         XCTAssertEqual(actions.integrationsToCancel!.count, 1)
-        XCTAssertFalse(actions.startNewIntegration ?? true)
+        XCTAssertNil(actions.startNewIntegrationBot)
         XCTBAssertNotNil(actions.githubStatusToSet)
-        XCTAssertEqual(actions.githubStatusToSet!.status.state, Status.State.Pending)
+        XCTAssertEqual(actions.githubStatusToSet!.status.status.state, Status.State.Pending)
     }
 
     func testTwoIntegrationsDifferentCommits() {
@@ -152,7 +151,7 @@ class SyncPair_PR_Bot_Tests: XCTestCase {
         let actions = SyncPair_PR_Bot.syncPRWithBotIntegrations(pr: pr, bot: bot, integrations: integrations)
         
         XCTAssertEqual(actions.integrationsToCancel!.count, 1)
-        XCTAssertTrue(actions.startNewIntegration!)
+        XCTAssertNotNil(actions.startNewIntegrationBot)
         XCTBAssertNil(actions.githubStatusToSet) //no change
     }
     

--- a/BuildasaurTests/SyncerTests.swift
+++ b/BuildasaurTests/SyncerTests.swift
@@ -22,6 +22,11 @@ class SyncerTests: XCTestCase {
         self.syncer = self.mockedSyncer()
     }
     
+    override func tearDown() {
+        self.syncer = nil
+        super.tearDown()
+    }
+    
     func mockedSyncer() -> HDGitHubXCBotSyncer {
         
         let xcodeServer = MockXcodeServer()
@@ -39,10 +44,13 @@ class SyncerTests: XCTestCase {
     
     func testCreatingChangeActions_NoPRs_NoBots() {
         
-        let (toSync, toCreate, toDelete) = self.syncer.resolvePRsAndBots(repoName: "me/Repo", prs: [], bots: [])
-        XCTAssertEqual(toSync.count, 0)
-        XCTAssertEqual(toCreate.count, 0)
-        XCTAssertEqual(toDelete.count, 0)
+        let botActions = self.syncer.resolvePRsAndBranchesAndBots(repoName: "me/Repo", prs: [], branches: [], bots: [])
+        
+        XCTAssertEqual(botActions.prsToSync.count, 0)
+        XCTAssertEqual(botActions.prBotsToCreate.count, 0)
+        XCTAssertEqual(botActions.branchesToSync.count, 0)
+        XCTAssertEqual(botActions.branchBotsToCreate.count, 0)
+        XCTAssertEqual(botActions.botsToDelete.count, 0)
     }
     
     func testCreatingChangeActions_MultiplePR_NoBots() {
@@ -52,10 +60,13 @@ class SyncerTests: XCTestCase {
             MockPullRequest(number: 7, title: "")
         ]
         
-        let (toSync, toCreate, toDelete) = self.syncer.resolvePRsAndBots(repoName: "me/Repo", prs: prs, bots: [])
-        XCTAssertEqual(toSync.count, 0)
-        XCTAssertEqual(toCreate.count, 2)
-        XCTAssertEqual(toDelete.count, 0)
+        let botActions = self.syncer.resolvePRsAndBranchesAndBots(repoName: "me/Repo", prs: prs, branches: [], bots: [])
+        
+        XCTAssertEqual(botActions.prsToSync.count, 0)
+        XCTAssertEqual(botActions.prBotsToCreate.count, 2)
+        XCTAssertEqual(botActions.branchesToSync.count, 0)
+        XCTAssertEqual(botActions.branchBotsToCreate.count, 0)
+        XCTAssertEqual(botActions.botsToDelete.count, 0)
     }
     
     func testCreatingChangeActions_NoPR_Bots() {
@@ -65,10 +76,13 @@ class SyncerTests: XCTestCase {
             MockBot(name: "BuildaBot [me/Repo] bot2")
         ]
         
-        let (toSync, toCreate, toDelete) = self.syncer.resolvePRsAndBots(repoName: "me/Repo", prs: [], bots: bots)
-        XCTAssertEqual(toSync.count, 0)
-        XCTAssertEqual(toCreate.count, 0)
-        XCTAssertEqual(toDelete.count, 1) //should only be one, because the first bot should get ignored, since it doesn't belong to me/Repo (judging by its name prefix)
+        let botActions = self.syncer.resolvePRsAndBranchesAndBots(repoName: "me/Repo", prs: [], branches: [], bots: bots)
+        
+        XCTAssertEqual(botActions.prsToSync.count, 0)
+        XCTAssertEqual(botActions.prBotsToCreate.count, 0)
+        XCTAssertEqual(botActions.branchesToSync.count, 0)
+        XCTAssertEqual(botActions.branchBotsToCreate.count, 0)
+        XCTAssertEqual(botActions.botsToDelete.count, 1) //should only be one, because the first bot should get ignored, since it doesn't belong to me/Repo (judging by its name prefix)
     }
     
     func testCreatingChangeActions_PRs_Bots() {
@@ -76,7 +90,9 @@ class SyncerTests: XCTestCase {
         let bots = [
             MockBot(name: "bot1"), //this should get ignored
             MockBot(name: "BuildaBot [me/Repo] PR #4"),
-            MockBot(name: "BuildaBot [me/Repo] PR #8")
+            MockBot(name: "BuildaBot [me/Repo] PR #8"),
+            MockBot(name: "BuildaBot [me/Repo] |-> cd/broke_something"),
+            MockBot(name: "BuildaBot [me/Repo] |-> gh/bot_to_delete"),
         ]
         
         let prs = [
@@ -84,14 +100,32 @@ class SyncerTests: XCTestCase {
             MockPullRequest(number: 7, title: "")
         ]
         
-        let (toSync, toCreate, toDelete) = self.syncer.resolvePRsAndBots(repoName: "me/Repo", prs: prs, bots: bots)
-        XCTAssertEqual(toSync.count, 1)
-        XCTAssertEqual(toSync.first!.bot.name, "BuildaBot [me/Repo] PR #4")
-        XCTAssertEqual(toSync.first!.pr.number, 4)
-        XCTAssertEqual(toCreate.count, 1)
-        XCTAssertEqual(toCreate.first!.number, 7)
-        XCTAssertEqual(toDelete.count, 1)
-        XCTAssertEqual(toDelete.first!.name, "BuildaBot [me/Repo] PR #8")
+        let branches = [
+            MockBranch(name: "cd/broke_something"),
+            MockBranch(name: "ab/fixed_errthing"),
+            MockBranch(name: "ef/migrating_from_php_to_mongo_db")
+        ]
+        
+        self.syncer.watchedBranchNames = [
+            "cd/broke_something",
+            "ef/migrating_from_php_to_mongo_db"
+        ]
+        
+        let botActions = self.syncer.resolvePRsAndBranchesAndBots(repoName: "me/Repo", prs: prs, branches: branches, bots: bots)
+
+        XCTAssertEqual(botActions.prsToSync.count, 1)
+        XCTAssertEqual(botActions.prsToSync.first!.bot.name, "BuildaBot [me/Repo] PR #4")
+        XCTAssertEqual(botActions.prsToSync.first!.pr.number, 4)
+        XCTAssertEqual(botActions.prBotsToCreate.count, 1)
+        XCTAssertEqual(botActions.prBotsToCreate.first!.number, 7)
+        XCTAssertEqual(botActions.branchesToSync.count, 1)
+        XCTAssertEqual(botActions.branchesToSync.first!.branch.name, "cd/broke_something")
+        XCTAssertEqual(botActions.branchBotsToCreate.count, 1)
+        XCTAssertEqual(botActions.branchBotsToCreate.first!.name, "ef/migrating_from_php_to_mongo_db")
+        XCTAssertEqual(botActions.botsToDelete.count, 2)
+        let toDelete = Set(botActions.botsToDelete.map({ $0.name }))
+        XCTAssertTrue(toDelete.contains("BuildaBot [me/Repo] PR #8"))
+        XCTAssertTrue(toDelete.contains("BuildaBot [me/Repo] |-> gh/bot_to_delete"))
     }
     
 }

--- a/BuildasaurTests/SyncerTests.swift
+++ b/BuildasaurTests/SyncerTests.swift
@@ -35,8 +35,16 @@ class SyncerTests: XCTestCase {
         let syncInterval = 15.0
         let waitForLttm = true
         let postStatusComments = true
+        let watchedBranchNames: [String] = []
         
-        let syncer = HDGitHubXCBotSyncer(integrationServer: xcodeServer, sourceServer: githubServer, localSource: project, syncInterval: syncInterval, waitForLttm: waitForLttm, postStatusComments: postStatusComments)
+        let syncer = HDGitHubXCBotSyncer(
+            integrationServer: xcodeServer,
+            sourceServer: githubServer,
+            localSource: project,
+            syncInterval: syncInterval,
+            waitForLttm: waitForLttm,
+            postStatusComments: postStatusComments,
+            watchedBranchNames: watchedBranchNames)
         return syncer
     }
     


### PR DESCRIPTION
Fixes #18.
- Now, not only Pull Requests, but you can also mark certain branches to be always watched (tested on Xcode Server and its commit's status updated on GitHub). I can see that being useful for `master`, so that when Pull Requests get merged, stability of master gets verified again.
- Right now the same Build Template as for PRs is used.
- If you delete a branch, it will get unwatched automatically. Also, if no branches are being watched, Buildasaur doesn't fetch them from GitHub, thus not delaying the sync interval for existing usecase.
- Watched branches can be edited in the UI, in the Syncer (bottom) section, click on `Branch Watching`.

Let me know if you find this useful!

This feature will get extended with #53.
