### PR TITLE
Fix status bar icon being invisible in dark mode

### DIFF
--- a/Buildasaur/MenuItemManager.swift
+++ b/Buildasaur/MenuItemManager.swift
@@ -19,7 +19,9 @@ class MenuItemManager : NSObject, NSMenuDelegate {
         
         let statusItem = statusBar.statusItemWithLength(32)
         statusItem.title = ""
-        statusItem.image = NSImage(named: "icon")
+        let image = NSImage(named: "icon")
+        image?.setTemplate(true)
+        statusItem.image = image
         statusItem.highlightMode = true
         
         var menu = NSMenu()


### PR DESCRIPTION
The icon image is currently not visible when using a dark status bar in OS X Yosemite. This PR fixes it by changing it into a template image.
