### PR TITLE
Clean testing device ids when scheme/device filter type is changed

### DIFF
--- a/Buildasaur/BuildTemplateViewController.swift
+++ b/Buildasaur/BuildTemplateViewController.swift
@@ -371,6 +371,10 @@ class BuildTemplateViewController: SetupViewController, NSComboBoxDelegate, NSTa
         return false
     }
 
+    private func cleanTestingDeviceIds() {
+        self.buildTemplate.testingDeviceIds = []
+    }
+    
     func comboBoxSelectionDidChange(notification: NSNotification) {
         
         if let comboBox = notification.object as? NSComboBox {
@@ -379,6 +383,7 @@ class BuildTemplateViewController: SetupViewController, NSComboBoxDelegate, NSTa
                 
                 self.pullFilterFromUI(true)
                 self.reloadUI()
+                self.cleanTestingDeviceIds()
                 
                 //filter changed, refetch
                 self.fetchDevices({ () -> () in
@@ -390,6 +395,7 @@ class BuildTemplateViewController: SetupViewController, NSComboBoxDelegate, NSTa
                     self.testDeviceFilterComboBox.selectItemAtIndex(0)
                 }
                 self.pullSchemeFromUI(true)
+                self.cleanTestingDeviceIds()
             }
         }
     }


### PR DESCRIPTION
Fixes #85, now testing device IDs are cleaned when the scheme/testing device type is changed, because when the testing device ids are present and Xcode Server can't build on them, the build fails (even when the testing device filter type is "All Devices" etc). This cleans the devices when the filter type changes and when scheme changes.
