### PR TITLE
Filter Build Templates by Project

### DIFF
--- a/Buildasaur.xcodeproj/project.pbxproj
+++ b/Buildasaur.xcodeproj/project.pbxproj
@@ -17,7 +17,7 @@
 		3A1546511B02A32C001EEB45 /* BuildaUtils.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 3AAF6E741A3CE4CC00C657FB /* BuildaUtils.framework */; };
 		3A15465B1B02A37D001EEB45 /* ScriptTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3A15465A1B02A37D001EEB45 /* ScriptTests.swift */; };
 		3A2F9D821A8FE5D700B0DB68 /* StorageManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3A2F9D811A8FE5D700B0DB68 /* StorageManager.swift */; };
-		3A2F9D861A8FE64900B0DB68 /* LocalSource.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3A2F9D841A8FE64900B0DB68 /* LocalSource.swift */; };
+		3A2F9D861A8FE64900B0DB68 /* Project.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3A2F9D841A8FE64900B0DB68 /* Project.swift */; };
 		3A2F9D871A8FE64900B0DB68 /* Syncer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3A2F9D851A8FE64900B0DB68 /* Syncer.swift */; };
 		3A32CD141A3D00F800861A34 /* Comment.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3A32CD131A3D00F800861A34 /* Comment.swift */; };
 		3A32CD181A3D01E300861A34 /* Issue.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3A32CD171A3D01E300861A34 /* Issue.swift */; };
@@ -180,7 +180,7 @@
 		3A15465A1B02A37D001EEB45 /* ScriptTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ScriptTests.swift; sourceTree = "<group>"; };
 		3A15465E1B02A4CE001EEB45 /* Info.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		3A2F9D811A8FE5D700B0DB68 /* StorageManager.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = StorageManager.swift; sourceTree = "<group>"; };
-		3A2F9D841A8FE64900B0DB68 /* LocalSource.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = LocalSource.swift; sourceTree = "<group>"; };
+		3A2F9D841A8FE64900B0DB68 /* Project.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Project.swift; sourceTree = "<group>"; };
 		3A2F9D851A8FE64900B0DB68 /* Syncer.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Syncer.swift; sourceTree = "<group>"; };
 		3A32CD131A3D00F800861A34 /* Comment.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Comment.swift; sourceTree = "<group>"; };
 		3A32CD171A3D01E300861A34 /* Issue.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Issue.swift; sourceTree = "<group>"; };
@@ -376,7 +376,7 @@
 			isa = PBXGroup;
 			children = (
 				3A612F001AADA28D00183BCB /* BuildTemplate.swift */,
-				3A2F9D841A8FE64900B0DB68 /* LocalSource.swift */,
+				3A2F9D841A8FE64900B0DB68 /* Project.swift */,
 				3AAA1B711AABBBB200FA1598 /* NetworkUtils.swift */,
 				3A2F9D811A8FE5D700B0DB68 /* StorageManager.swift */,
 				3A4770A11A745F470016E170 /* StorageUtils.swift */,
@@ -1164,7 +1164,7 @@
 				3A5591561A913C0A00FB19F2 /* XcodeLocalSource.swift in Sources */,
 				3A5687781A3B93BD0066DB2B /* MainViewController.swift in Sources */,
 				3A46A2CA1B07E28700F0FA4B /* SyncPair.swift in Sources */,
-				3A2F9D861A8FE64900B0DB68 /* LocalSource.swift in Sources */,
+				3A2F9D861A8FE64900B0DB68 /* Project.swift in Sources */,
 				3A46A2C11B07D8D800F0FA4B /* SyncerBotNaming.swift in Sources */,
 				3AF090B81B1134AA0058567F /* BranchWatchingViewController.swift in Sources */,
 				3A0BC0491B0BFB5D0020AB9F /* SyncPair_Branch_NoBot.swift in Sources */,

--- a/Buildasaur.xcodeproj/xcshareddata/xcschemes/Buildasaur.xcscheme
+++ b/Buildasaur.xcodeproj/xcshareddata/xcschemes/Buildasaur.xcscheme
@@ -107,10 +107,11 @@
       </BuildActionEntries>
    </BuildAction>
    <TestAction
+      buildConfiguration = "Debug"
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
       shouldUseLaunchSchemeArgsEnv = "YES"
-      buildConfiguration = "Debug">
+      codeCoverageEnabled = "YES">
       <Testables>
          <TestableReference
             skipped = "NO">
@@ -186,11 +187,11 @@
       </AdditionalOptions>
    </TestAction>
    <LaunchAction
+      buildConfiguration = "Debug"
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
       launchStyle = "0"
       useCustomWorkingDirectory = "NO"
-      buildConfiguration = "Debug"
       ignoresPersistentStateOnLaunch = "NO"
       debugDocumentVersioning = "YES"
       debugServiceExtension = "internal"
@@ -209,10 +210,10 @@
       </AdditionalOptions>
    </LaunchAction>
    <ProfileAction
+      buildConfiguration = "Release"
       shouldUseLaunchSchemeArgsEnv = "YES"
       savedToolIdentifier = ""
       useCustomWorkingDirectory = "NO"
-      buildConfiguration = "Release"
       debugDocumentVersioning = "YES">
       <BuildableProductRunnable
          runnableDebuggingMode = "0">

--- a/Buildasaur/BranchWatchingViewController.swift
+++ b/Buildasaur/BranchWatchingViewController.swift
@@ -46,7 +46,7 @@ class BranchWatchingViewController: NSViewController, NSTableViewDelegate, NSTab
     func fetchBranches(completion: ([Branch]?, NSError?) -> ()) {
         
         self.branchActivityIndicator.startAnimation(nil)
-        let repoName = self.syncer.localSource.githubRepoName()!
+        let repoName = self.syncer.project.githubRepoName()!
         self.syncer.github.getBranchesOfRepo(repoName, completion: { (branches, error) -> () in
             
             NSOperationQueue.mainQueue().addOperationWithBlock({ () -> Void in

--- a/Buildasaur/BuildTemplate.swift
+++ b/Buildasaur/BuildTemplate.swift
@@ -11,6 +11,7 @@ import BuildaUtils
 import XcodeServerSDK
 
 private let kKeyUniqueId = "id"
+private let kKeyProjectName = "project_name"
 private let kKeyName = "name"
 private let kKeyScheme = "scheme"
 private let kKeySchedule = "schedule"
@@ -25,7 +26,9 @@ private let kKeyShouldArchive = "should_archive"
 
 class BuildTemplate: JSONSerializable {
     
-    var uniqueId: String //unique id of this build template, so that we can rename them easily
+    let uniqueId: String //unique id of this build template, so that we can rename them easily
+    
+    var projectName: String?
     var name: String?
     var scheme: String?
     var schedule: BotSchedule? //will be ignored for Synced bots, only useful for Manual creation. default: Manual
@@ -47,9 +50,10 @@ class BuildTemplate: JSONSerializable {
         return true
     }
     
-    init() {
+    init(projectName: String) {
         self.uniqueId = NSUUID().UUIDString
-        self.name = "New Build Template Name"
+        self.projectName = projectName
+        self.name = "New Build Template"
         self.scheme = nil
         self.schedule = BotSchedule.manualBotSchedule()
         self.cleaningPolicy = BotConfiguration.CleaningPolicy.Never
@@ -65,6 +69,7 @@ class BuildTemplate: JSONSerializable {
     required init?(json: NSDictionary) {
         
         self.uniqueId = json.optionalStringForKey(kKeyUniqueId) ?? ""
+        self.projectName = json.optionalStringForKey(kKeyProjectName)
         self.name = json.optionalStringForKey(kKeyName)
         self.scheme = json.optionalStringForKey(kKeyScheme)
         if let scheduleDict = json.optionalDictionaryForKey(kKeySchedule) {
@@ -121,6 +126,7 @@ class BuildTemplate: JSONSerializable {
         dict[kKeyDeviceFilter] = self.deviceFilter.rawValue
         dict[kKeyTestingDevices] = self.testingDeviceIds ?? []
         dict[kKeyCleaningPolicy] = self.cleaningPolicy.rawValue
+        dict.optionallyAddValueForKey(self.projectName, key: kKeyProjectName)
         dict.optionallyAddValueForKey(self.name, key: kKeyName)
         dict.optionallyAddValueForKey(self.scheme, key: kKeyScheme)
         dict.optionallyAddValueForKey(self.schedule?.dictionarify(), key: kKeySchedule)

--- a/Buildasaur/BuildTemplateViewController.swift
+++ b/Buildasaur/BuildTemplateViewController.swift
@@ -14,7 +14,7 @@ import XcodeServerSDK
 class BuildTemplateViewController: SetupViewController, NSComboBoxDelegate, NSTableViewDataSource, NSTableViewDelegate, SetupViewControllerDelegate, NSComboBoxDataSource {
     
     var storageManager: StorageManager!
-    var project: LocalSource!
+    var project: Project!
     var buildTemplate: BuildTemplate!
     var xcodeServer: XcodeServer?
     
@@ -77,7 +77,10 @@ class BuildTemplateViewController: SetupViewController, NSComboBoxDelegate, NSTa
         self.schemesComboBox.addItemsWithObjectValues(schemes)
         
         let temp = self.buildTemplate
-        
+
+        let projectName = self.project.projectName
+        self.buildTemplate.projectName = projectName
+
         //name
         self.nameTextField.stringValue = temp.name ?? ""
         
@@ -124,8 +127,6 @@ class BuildTemplateViewController: SetupViewController, NSComboBoxDelegate, NSTa
         if let destinationIndex = filters.indexOfFirstObjectPassingTest({ $0 == filter }) {
             self.testDeviceFilterComboBox.selectItemAtIndex(destinationIndex)
         }
-        
-        return
     }
     
     func fetchDevices(completion: () -> ()) {

--- a/Buildasaur/HDGitHubXCBotSyncer.swift
+++ b/Buildasaur/HDGitHubXCBotSyncer.swift
@@ -22,19 +22,19 @@ public class HDGitHubXCBotSyncer : Syncer {
     
     let github: GitHubServer!
     let xcodeServer: XcodeServer!
-    let localSource: LocalSource!
+    let project: Project!
     let waitForLttm: Bool
     let postStatusComments: Bool
     public var watchedBranchNames: [String]
     
     public typealias GitHubStatusAndComment = (status: Status, comment: String?)
     
-    public init(integrationServer: XcodeServer, sourceServer: GitHubServer, localSource: LocalSource,
+    public init(integrationServer: XcodeServer, sourceServer: GitHubServer, project: Project,
         syncInterval: NSTimeInterval, waitForLttm: Bool, postStatusComments: Bool, watchedBranchNames: [String]) {
             
             self.github = sourceServer
             self.xcodeServer = integrationServer
-            self.localSource = localSource
+            self.project = project
             self.waitForLttm = waitForLttm
             self.postStatusComments = postStatusComments
             self.watchedBranchNames = watchedBranchNames
@@ -50,7 +50,7 @@ public class HDGitHubXCBotSyncer : Syncer {
             let project = storageManager.projects.filter({ $0.url.absoluteString == projectPath }).first,
             let serverConfig = storageManager.servers.filter({ $0.host == serverHost }).first
         {
-            self.localSource = project
+            self.project = project
             self.github = GitHubFactory.server(project.githubToken)
             self.xcodeServer = XcodeServerFactory.server(serverConfig)
             self.waitForLttm = json.optionalBoolForKey("wait_for_lttm") ?? true
@@ -62,7 +62,7 @@ public class HDGitHubXCBotSyncer : Syncer {
             
             self.github = nil
             self.xcodeServer = nil
-            self.localSource = nil
+            self.project = nil
             self.waitForLttm = true
             self.postStatusComments = true
             self.watchedBranchNames = []
@@ -75,7 +75,7 @@ public class HDGitHubXCBotSyncer : Syncer {
         
         let dict = NSMutableDictionary()
         dict["sync_interval"] = self.syncInterval
-        dict["project_path"] = self.localSource.url.absoluteString
+        dict["project_path"] = self.project.url.absoluteString
         dict["server_host"] = self.xcodeServer.config.host
         dict["wait_for_lttm"] = self.waitForLttm
         dict["post_status_comments"] = self.postStatusComments
@@ -84,7 +84,7 @@ public class HDGitHubXCBotSyncer : Syncer {
     }
     
     func repoName() -> String? {
-        return self.localSource.githubRepoName()
+        return self.project.githubRepoName()
     }
     
     //TODO: migrate this shit to RAC, the callback hell below hurts my eyes (you've been warned)

--- a/Buildasaur/MainViewController.swift
+++ b/Buildasaur/MainViewController.swift
@@ -18,7 +18,7 @@ class MainViewController: NSViewController, NSTableViewDataSource, StatusSibling
     var projectStatusViewController: StatusProjectViewController!
     var serverStatusViewController: StatusServerViewController!
     
-    private var buildTemplateParams: (buildTemplate: BuildTemplate?, project: LocalSource)?
+    private var buildTemplateParams: (buildTemplate: BuildTemplate?, project: Project)?
     
     required init?(coder: NSCoder) {
         
@@ -74,7 +74,7 @@ class MainViewController: NSViewController, NSTableViewDataSource, StatusSibling
         return self.serverStatusViewController
     }
     
-    func showBuildTemplateViewControllerForTemplate(template: BuildTemplate?, project: LocalSource, sender: SetupViewControllerDelegate?) {
+    func showBuildTemplateViewControllerForTemplate(template: BuildTemplate?, project: Project, sender: SetupViewControllerDelegate?) {
 
         self.buildTemplateParams = (buildTemplate: template, project: project)
         self.performSegueWithIdentifier("showBuildTemplate", sender: sender)

--- a/Buildasaur/ManualBotManagementViewController.swift
+++ b/Buildasaur/ManualBotManagementViewController.swift
@@ -47,7 +47,7 @@ class ManualBotManagementViewController: NSViewController {
     func fetchBranches(completion: ([Branch]?, NSError?) -> ()) {
         
         self.branchActivityIndicator.startAnimation(nil)
-        let repoName = self.syncer.localSource.githubRepoName()!
+        let repoName = self.syncer.project.githubRepoName()!
         self.syncer.github.getBranchesOfRepo(repoName, completion: { (branches, error) -> () in
             
             NSOperationQueue.mainQueue().addOperationWithBlock({ () -> Void in
@@ -101,7 +101,7 @@ class ManualBotManagementViewController: NSViewController {
             let branch = self.pullBranchName(),
             let template = self.pullTemplate()
         {
-            let project = self.syncer.localSource
+            let project = self.syncer.project
             let xcodeServer = self.syncer.xcodeServer
             
             self.creatingActivityIndicator.startAnimation(nil)

--- a/Buildasaur/MenuItemManager.swift
+++ b/Buildasaur/MenuItemManager.swift
@@ -64,7 +64,7 @@ class MenuItemManager : NSObject, NSMenuDelegate {
             }
             
             let repo: String
-            if let repoName = syncer.localSource.githubRepoName() {
+            if let repoName = syncer.project.githubRepoName() {
                 repo = repoName
             } else {
                 repo = "???"

--- a/Buildasaur/NetworkUtils.swift
+++ b/Buildasaur/NetworkUtils.swift
@@ -13,11 +13,11 @@ import XcodeServerSDK
 
 class NetworkUtils {
     
-    class func checkAvailabilityOfGitHubWithCurrentSettingsOfProject(project: LocalSource, completion: (success: Bool, error: NSError?) -> ()) {
+    class func checkAvailabilityOfGitHubWithCurrentSettingsOfProject(project: Project, completion: (success: Bool, error: NSError?) -> ()) {
         
         let token = project.githubToken
         let server = GitHubFactory.server(token)
-        let credentialValidationBlueprint = project.createSourceControlBlueprintForCredentialVerification()
+//        let credentialValidationBlueprint = project.createSourceControlBlueprintForCredentialVerification()
         
         //check if we can get PRs, that should be representative enough
         if let repoName = project.githubRepoName() {

--- a/Buildasaur/Project.swift
+++ b/Buildasaur/Project.swift
@@ -1,5 +1,5 @@
 //
-//  LocalSource.swift
+//  Project.swift
 //  Buildasaur
 //
 //  Created by Honza Dvorsky on 14/02/2015.

--- a/Buildasaur/Project.swift
+++ b/Buildasaur/Project.swift
@@ -10,7 +10,7 @@ import Foundation
 import BuildaUtils
 import XcodeServerSDK
 
-public class LocalSource : JSONSerializable {
+public class Project : JSONSerializable {
     
     enum AllowedCheckoutTypes: String {
         case SSH = "SSH"
@@ -83,7 +83,7 @@ public class LocalSource : JSONSerializable {
         get {
             if
                 let meta = self.workspaceMetadata,
-                let type = LocalSource.parseCheckoutType(meta) {
+                let type = Project.parseCheckoutType(meta) {
                     return type
             }
             return nil
@@ -112,7 +112,7 @@ public class LocalSource : JSONSerializable {
         }
     }
     
-    private init?(original: LocalSource, forkOriginURL: String) {
+    private init?(original: Project, forkOriginURL: String) {
         
         self.forkOriginURL = forkOriginURL
         self.url = original.url
@@ -130,14 +130,14 @@ public class LocalSource : JSONSerializable {
         }
     }
     
-    public func duplicateForForkAtOriginURL(forkURL: String) -> LocalSource? {
+    public func duplicateForForkAtOriginURL(forkURL: String) -> Project? {
         
-        return LocalSource(original: self, forkOriginURL: forkURL)
+        return Project(original: self, forkOriginURL: forkURL)
     }
     
     public class func attemptToParseFromUrl(url: NSURL) throws -> NSDictionary {
         
-        let meta = try LocalSource.loadWorkspaceMetadata(url)
+        let meta = try Project.loadWorkspaceMetadata(url)
         
         //validate allowed remote url
         if self.parseCheckoutType(meta) == nil {
@@ -180,7 +180,7 @@ public class LocalSource : JSONSerializable {
 
     private func refreshMetadata() throws {
         
-        let meta = try LocalSource.attemptToParseFromUrl(self.url)
+        let meta = try Project.attemptToParseFromUrl(self.url)
         self.workspaceMetadata = meta
     }
     

--- a/Buildasaur/StatusProjectViewController.swift
+++ b/Buildasaur/StatusProjectViewController.swift
@@ -51,7 +51,7 @@ class StatusProjectViewController: StatusViewController, NSComboBoxDelegate, Set
         self.lastAvailabilityCheckStatus = .Unchecked
     }
         
-    func project() -> LocalSource? {
+    func project() -> Project? {
         return self.storageManager.projects.first
     }
     
@@ -173,7 +173,7 @@ class StatusProjectViewController: StatusViewController, NSComboBoxDelegate, Set
                 buildTemplate = self.storageManager.buildTemplates.filter({ $0.name == templatePulled }).first
             }
             if buildTemplate == nil {
-                buildTemplate = BuildTemplate()
+                buildTemplate = BuildTemplate(projectName: self.project()!.projectName!)
             }
             
             self.delegate.showBuildTemplateViewControllerForTemplate(buildTemplate, project: self.project()!, sender: self)

--- a/Buildasaur/StatusViewController.swift
+++ b/Buildasaur/StatusViewController.swift
@@ -15,7 +15,7 @@ protocol StatusSiblingsViewControllerDelegate: class {
     
     func getProjectStatusViewController() -> StatusProjectViewController
     func getServerStatusViewController() -> StatusServerViewController
-    func showBuildTemplateViewControllerForTemplate(template: BuildTemplate?, project: LocalSource, sender: SetupViewControllerDelegate?)
+    func showBuildTemplateViewControllerForTemplate(template: BuildTemplate?, project: Project, sender: SetupViewControllerDelegate?)
 }
 
 class StatusViewController: NSViewController {

--- a/Buildasaur/StorageManager.swift
+++ b/Buildasaur/StorageManager.swift
@@ -19,7 +19,7 @@ class StorageManager {
     
     private(set) var syncers: [HDGitHubXCBotSyncer] = []
     private(set) var servers: [XcodeServerConfig] = []
-    private(set) var projects: [LocalSource] = []
+    private(set) var projects: [Project] = []
     private(set) var buildTemplates: [BuildTemplate] = []
     
     init() {
@@ -34,11 +34,11 @@ class StorageManager {
     
     func addProjectAtURL(url: NSURL) throws {
         
-        _ = try LocalSource.attemptToParseFromUrl(url)
-        if let localSource = LocalSource(url: url) {
-            self.projects.append(localSource)
+        _ = try Project.attemptToParseFromUrl(url)
+        if let project = Project(url: url) {
+            self.projects.append(project)
         } else {
-            assertionFailure("Attempt to parse succeeded but LocalSource still wasn't created")
+            assertionFailure("Attempt to parse succeeded but Project still wasn't created")
         }
     }
     
@@ -48,7 +48,7 @@ class StorageManager {
     }
     
     func addSyncer(syncInterval: NSTimeInterval, waitForLttm: Bool, postStatusComments: Bool,
-        project: LocalSource, serverConfig: XcodeServerConfig, watchedBranchNames: [String]) -> HDGitHubXCBotSyncer? {
+        project: Project, serverConfig: XcodeServerConfig, watchedBranchNames: [String]) -> HDGitHubXCBotSyncer? {
 
         if syncInterval <= 0 {
             Log.error("Sync interval must be > 0 seconds.")
@@ -60,7 +60,7 @@ class StorageManager {
         let syncer = HDGitHubXCBotSyncer(
             integrationServer: xcodeServer,
             sourceServer: github,
-            localSource: project,
+            project: project,
             syncInterval: syncInterval,
             waitForLttm: waitForLttm,
             postStatusComments: postStatusComments,
@@ -109,7 +109,7 @@ class StorageManager {
         self.saveBuildTemplates()
     }
     
-    func removeProject(project: LocalSource) {
+    func removeProject(project: Project) {
         
         for (idx, p) in self.projects.enumerate() {
             if project.url == p.url {
@@ -180,7 +180,7 @@ class StorageManager {
             let json = try Persistence.loadJSONFromUrl(projectsUrl)
             
             if let json = json as? [NSDictionary] {
-                let allProjects = json.map { LocalSource(json: $0) }
+                let allProjects = json.map { Project(json: $0) }
                 let parsedProjects = allProjects.filter { $0 != nil }.map { $0! }
                 if allProjects.count != parsedProjects.count {
                     Log.error("Some projects failed to parse, will be ignored.")

--- a/Buildasaur/SyncerBotManipulation.swift
+++ b/Buildasaur/SyncerBotManipulation.swift
@@ -60,22 +60,22 @@ extension HDGitHubXCBotSyncer {
         
         //to handle forks
         let headOriginUrl = repo.repoUrlSSH
-        let localProjectOriginUrl = self.localSource.projectURL!.absoluteString
+        let localProjectOriginUrl = self.project.projectURL!.absoluteString
         
-        let project: LocalSource
+        let project: Project
         if headOriginUrl != localProjectOriginUrl {
             
             //we have a fork, duplicate the metadata with the fork's origin
-            if let source = self.localSource.duplicateForForkAtOriginURL(headOriginUrl) {
+            if let source = self.project.duplicateForForkAtOriginURL(headOriginUrl) {
                 project = source
             } else {
-                self.notifyError(Error.withInfo("Couldn't create a LocalSource for fork with origin at url \(headOriginUrl)"), context: "Creating a bot from a PR")
+                self.notifyError(Error.withInfo("Couldn't create a Project for fork with origin at url \(headOriginUrl)"), context: "Creating a bot from a PR")
                 completion()
                 return
             }
         } else {
-            //a normal PR in the same repo, no need to duplicate, just use the existing localSource
-            project = self.localSource
+            //a normal PR in the same repo, no need to duplicate, just use the existing project
+            project = self.project
         }
         
         let xcodeServer = self.xcodeServer
@@ -108,7 +108,7 @@ extension HDGitHubXCBotSyncer {
     private func currentBuildTemplate() -> BuildTemplate! {
         
         if
-            let preferredTemplateId = self.localSource.preferredTemplateId,
+            let preferredTemplateId = self.project.preferredTemplateId,
             let template = StorageManager.sharedInstance.buildTemplates.filter({ $0.uniqueId == preferredTemplateId }).first {
                 return template
         }

--- a/Buildasaur/XcodeLocalSource.swift
+++ b/Buildasaur/XcodeLocalSource.swift
@@ -1,5 +1,5 @@
 //
-//  XcodeLocalSource.swift
+//  XcodeProject.swift
 //  Buildasaur
 //
 //  Created by Honza Dvorsky on 15/02/2015.
@@ -9,7 +9,7 @@
 import Foundation
 import XcodeServerSDK
 
-extension LocalSource {
+extension Project {
     
     public func createSourceControlBlueprint(branch: String) -> SourceControlBlueprint {
         

--- a/Buildasaur/XcodeServerSyncerUtils.swift
+++ b/Buildasaur/XcodeServerSyncerUtils.swift
@@ -13,7 +13,7 @@ import BuildaUtils
 
 class XcodeServerSyncerUtils {
     
-    class func createBotFromBuildTemplate(botName: String, template: BuildTemplate, project: LocalSource, branch: String, scheduleOverride: BotSchedule?, xcodeServer: XcodeServer, completion: (bot: Bot?, error: NSError?) -> ()) {
+    class func createBotFromBuildTemplate(botName: String, template: BuildTemplate, project: Project, branch: String, scheduleOverride: BotSchedule?, xcodeServer: XcodeServer, completion: (bot: Bot?, error: NSError?) -> ()) {
         
         //pull info from template
         let schemeName = template.scheme!

--- a/BuildasaurTests/Mocks.swift
+++ b/BuildasaurTests/Mocks.swift
@@ -25,7 +25,7 @@ class MockGitHubServer: GitHubServer {
     }
 }
 
-class MockLocalSource: LocalSource {
+class MockProject: Project {
     override init() {
         super.init()
     }

--- a/BuildasaurTests/SyncerTests.swift
+++ b/BuildasaurTests/SyncerTests.swift
@@ -31,7 +31,7 @@ class SyncerTests: XCTestCase {
         
         let xcodeServer = MockXcodeServer()
         let githubServer = MockGitHubServer()
-        let project = MockLocalSource()
+        let project = MockProject()
         let syncInterval = 15.0
         let waitForLttm = true
         let postStatusComments = true
@@ -40,7 +40,7 @@ class SyncerTests: XCTestCase {
         let syncer = HDGitHubXCBotSyncer(
             integrationServer: xcodeServer,
             sourceServer: githubServer,
-            localSource: project,
+            project: project,
             syncInterval: syncInterval,
             waitForLttm: waitForLttm,
             postStatusComments: postStatusComments,


### PR DESCRIPTION
- Fixes #96.
- Also fixed the annoying bug where the preferred Build Template name would stay when a Project was removed and re-added.
- Renamed `LocalSource` to `Project`
