### PR TITLE
Issue 93: Analytics

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,5 +26,4 @@ DerivedData
 #
 Pods/
 Podfile.local
-Podfile.lock
 

--- a/.gitignore
+++ b/.gitignore
@@ -26,3 +26,5 @@ DerivedData
 #
 Pods/
 Podfile.local
+Podfile.lock
+

--- a/BuildaAnalytics/BuildaAnalytics.h
+++ b/BuildaAnalytics/BuildaAnalytics.h
@@ -1,0 +1,19 @@
+//
+//  BuildaAnalytics.h
+//  BuildaAnalytics
+//
+//  Created by Wyatt McBain on 8/24/15.
+//  Copyright © 2015 Honza Dvorsky. All rights reserved.
+//
+
+#import <Cocoa/Cocoa.h>
+
+//! Project version number for BuildaAnalytics.
+FOUNDATION_EXPORT double BuildaAnalyticsVersionNumber;
+
+//! Project version string for BuildaAnalytics.
+FOUNDATION_EXPORT const unsigned char BuildaAnalyticsVersionString[];
+
+// In this header, you should import all the public headers of your framework using statements like #import <BuildaAnalytics/PublicHeader.h>
+
+

--- a/BuildaAnalytics/BuildaAnalytics.swift
+++ b/BuildaAnalytics/BuildaAnalytics.swift
@@ -1,0 +1,117 @@
+//
+//  BuildaAnalytics.swift
+//  Buildasaur
+//
+//  Created by Wyatt McBain on 8/24/15.
+//  Copyright © 2015 Honza Dvorsky. All rights reserved.
+//
+
+import Cocoa
+
+import Tapstream
+
+// MARK: BuildaAnalyticsEvent
+
+/**
+    The BuildaAnalyticsEvent hold information regarding a analytics event.
+    
+    - event: The Tapstream event object
+*/
+public struct BuildaAnalyticsEvent {
+    let event: TSEvent
+    
+    public init(funnel: AnalyticsFunnel, event: AnalyticsEvent) {
+        self.event = {
+            let event = TSEvent.eventWithName(event.analyticsString, oneTimeOnly: false)
+            event.addValue(funnel.funnelString, forKey: "funnel")
+            return event as! TSEvent
+        }()
+    }
+}
+
+// MARK: BuildaAnalytics
+
+/**
+    BuildaAnalytics handles the core responsibilities of our events package.
+    Contains a single shared instance of BuildaAnalytics and sets up the configuration
+    of Tapstream's Analytics SDK.
+*/
+public class BuildaAnalytics: NSObject {
+    
+    /**
+        The shared BuildaAnalytics object. One should only be created, to prevent
+        multiple Tapstream instances from being created.
+    */
+    public class var sharedInstance: BuildaAnalytics {
+        struct Static {
+            static let instance: BuildaAnalytics = BuildaAnalytics()
+        }
+        return Static.instance
+    }
+    
+    /**
+        While we don't want to track any identifying personal information, it's still
+        logical to create unique identifiers for our users so we can determine patterns
+        for different types of users.
+    */
+    private var uniqueRandomIdentifier: String {
+        let userDefaults = NSUserDefaults.standardUserDefaults()
+        
+        if let existingID = userDefaults.stringForKey("analytics-identifier") {
+            return existingID
+        }
+        
+        let newID = NSUUID().UUIDString
+        userDefaults.setObject(newID, forKey: "analytics-identifier")
+        return newID
+    }
+    
+    
+    // MARK: Initializers
+    
+    private override init() {
+        super.init()
+        self.setupAnalytics()
+    }
+    
+    
+    // MARK: Event Handlers
+    
+    /**
+        Fires an analytics event and sends the information to Tapstream
+
+        :param: event - The BuildaAnalytics event to be sent
+    */
+    public func fireAnalyticsEvent(event: BuildaAnalyticsEvent) {
+        let tapstream = TSTapstream.instance()
+        tapstream.fireEvent(event.event)
+    }
+    
+    
+    // MARK: Setup 
+    
+    /**
+        Initializes our Analytics object with configuration settings to prevent
+        tracking user identifying information.
+    */
+    private func setupAnalytics() {
+        
+        // Analytics Settings
+        let accountName     =  "accountName"
+        let accountSecret   =   "accountSecret"
+        
+        if let config = TSConfig.configWithDefaults() as? TSConfig {
+            
+            config.collectWifiMac               = false // disable default user tracking
+            config.fireAutomaticInstallEvent    = false // disable install event
+            config.fireAutomaticOpenEvent       = false // disable default open event
+            config.fireAutomaticIAPEvents       = false // disable in app purchases
+                            
+            // Set user identifier.
+            config.globalEventParams.setValue(self.uniqueRandomIdentifier, forKey: "user")
+                 
+            // Create Tapstream Analytics object
+            TSTapstream.createWithAccountName(accountName, developerSecret: accountSecret, config: config)
+        }
+    }
+}

--- a/BuildaAnalytics/BuildaAnalyticsEvents.swift
+++ b/BuildaAnalytics/BuildaAnalyticsEvents.swift
@@ -1,0 +1,124 @@
+//
+//  BuildaAnalyticsEvents.swift
+//  Buildasaur
+//
+//  Created by Wyatt McBain on 8/24/15.
+//  Copyright © 2015 Honza Dvorsky. All rights reserved.
+//
+
+import Foundation
+
+extension String {
+    
+    /**
+        Ensures that strings are appropriately formatted for analytics.
+        Analytics event strings should be lower case and hyphenated.
+
+        :returns: The formatted analytics String.
+    */
+    func toAnalyticsString() -> String {
+        return self.lowercaseString.stringByReplacingOccurrencesOfString(" ", withString: "-")
+    }
+}
+
+/**
+    The AnalyticsFunnel enumeration defines various funnels that the user
+    initiates while using Buildasaur. Having funnel definitions allows us
+    to break up analytics events into logical groups.
+
+    - Xcode:                    Xcode Server Funnel
+    - Github:                   Github Funnel
+    - Feature:                  Application Features
+    - Other(funnel: String):    Other Funnel - Pass String to define.
+*/
+public enum AnalyticsFunnel {
+    case Xcode, Github, Feature, Other(funnel: String)
+    
+    public var funnelString: String {
+        switch self {
+        case .Xcode:
+            return "xcode-integration"
+        case .Github:
+            return "github-integration"
+        case .Feature:
+            return "buildasaur-feature"
+        case Other(let funnel):
+            return funnel.toAnalyticsString()
+        }
+    }
+}
+
+/**
+    The AnalyticsEvent protocol defines variables and functions
+    that Analytics Event enumerations must implement.
+*/
+public protocol AnalyticsEvent {
+    
+    /**
+        Retrieves the analytics string for a enumeration.
+    */
+    var analyticsString: String { get }
+}
+
+/**
+    The XcodeAnalyticsEvent enumeration defines various Xcode events
+    that we track as part of our Analytics package. Should be used when the
+    analytics funnel definition is .Xcode.
+
+    - BotCreation:              Bot was created
+    - Other(event: String):     Other event - Pass String to define.
+*/
+public enum XcodeAnalyticsEvent: AnalyticsEvent {
+    case BotCreation, Other(event: String)
+    
+    public var analyticsString: String {
+        switch self {
+        case .BotCreation:
+            return "bot-creation"
+        case Other(let event):
+            return event.toAnalyticsString()
+        }
+    }
+}
+
+/**
+    The GithubAnalyticsEvent enumeration defines various Github events
+    that we track as part of our analytics package. Should be used when the
+    analytics funnel definition is .Github.
+
+    - PullRequest:              Pull request event
+    - Other(event: String):     Other event - Pass String to define.
+*/
+public enum GithubAnalyticsEvent: AnalyticsEvent {
+    case PullRequest, Other(event: String)
+    
+    public var analyticsString: String {
+        switch self {
+        case .PullRequest:
+            return "pull-request"
+        case .Other(let event):
+            return event.toAnalyticsString()
+        }
+    }
+}
+
+/**
+    The FeatureAnalyticsEvent enumeration defines various Buildasaur Feature events
+    that we track as part of our analytics package. Should be used when the
+    analytics funnel definition is .Feature.
+
+    - OpenApp:                  Application is opened.
+    - Other(event: String):     Other event - Pass String to define.
+*/
+public enum FeatureAnalyticsEvent: AnalyticsEvent {
+    case OpenApp, Other(event: String)
+    
+    public var analyticsString: String {
+        switch self {
+        case .OpenApp:
+            return "open-application"
+        case .Other(let event):
+            return event.toAnalyticsString()
+        }
+    }
+}

--- a/BuildaAnalytics/Info.plist
+++ b/BuildaAnalytics/Info.plist
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>CFBundleDevelopmentRegion</key>
+	<string>en</string>
+	<key>CFBundleExecutable</key>
+	<string>$(EXECUTABLE_NAME)</string>
+	<key>CFBundleIdentifier</key>
+	<string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
+	<key>CFBundleInfoDictionaryVersion</key>
+	<string>6.0</string>
+	<key>CFBundleName</key>
+	<string>$(PRODUCT_NAME)</string>
+	<key>CFBundlePackageType</key>
+	<string>FMWK</string>
+	<key>CFBundleShortVersionString</key>
+	<string>1.0</string>
+	<key>CFBundleSignature</key>
+	<string>????</string>
+	<key>CFBundleVersion</key>
+	<string>$(CURRENT_PROJECT_VERSION)</string>
+	<key>NSHumanReadableCopyright</key>
+	<string>Copyright © 2015 Honza Dvorsky. All rights reserved.</string>
+	<key>NSPrincipalClass</key>
+	<string></string>
+</dict>
+</plist>

--- a/BuildaAnalyticsTests/BuildaAnalyticsTests.swift
+++ b/BuildaAnalyticsTests/BuildaAnalyticsTests.swift
@@ -1,0 +1,34 @@
+//
+//  BuildaAnalyticsTests.swift
+//  BuildaAnalyticsTests
+//
+//  Created by Wyatt McBain on 8/24/15.
+//  Copyright © 2015 Honza Dvorsky. All rights reserved.
+//
+
+import XCTest
+@testable import BuildaAnalytics
+
+import Tapstream
+
+class BuildaAnalyticsTests: XCTestCase {
+    
+    func testBuildaAnalyticsAlwaysReturnsOneInstance() {
+        let buildaAnalyticsFirst    = BuildaAnalytics.sharedInstance
+        let buildaAnalyticsSecond   = BuildaAnalytics.sharedInstance
+        
+        XCTAssertTrue(buildaAnalyticsFirst == buildaAnalyticsSecond, "Both analytics objects should be equal")
+    }
+    
+    func testCreatingOtherEnumsGeneratesFormattedString() {
+        let funnelOther = AnalyticsFunnel.Other(funnel: "some other funnel")
+        let xcodeOther = XcodeAnalyticsEvent.Other(event: "some other xcode")
+        let githubOther = GithubAnalyticsEvent.Other(event: "some other github")
+        let featureOther = FeatureAnalyticsEvent.Other(event: "some other feature")
+        
+        XCTAssertTrue(funnelOther.funnelString == "some-other-funnel", "Expected: some-other-funnel")
+        XCTAssertTrue(xcodeOther.analyticsString == "some-other-xcode", "Expected: some-other-xcode")
+        XCTAssertTrue(githubOther.analyticsString == "some-other-github", "Expected: some-other-github")
+        XCTAssertTrue(featureOther.analyticsString == "some-other-feature", "Expected: some-other-feature")
+    }
+}

--- a/BuildaAnalyticsTests/Info.plist
+++ b/BuildaAnalyticsTests/Info.plist
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>CFBundleDevelopmentRegion</key>
+	<string>en</string>
+	<key>CFBundleExecutable</key>
+	<string>$(EXECUTABLE_NAME)</string>
+	<key>CFBundleIdentifier</key>
+	<string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
+	<key>CFBundleInfoDictionaryVersion</key>
+	<string>6.0</string>
+	<key>CFBundleName</key>
+	<string>$(PRODUCT_NAME)</string>
+	<key>CFBundlePackageType</key>
+	<string>BNDL</string>
+	<key>CFBundleShortVersionString</key>
+	<string>1.0</string>
+	<key>CFBundleSignature</key>
+	<string>????</string>
+	<key>CFBundleVersion</key>
+	<string>1</string>
+</dict>
+</plist>

--- a/Buildasaur.xcodeproj/project.pbxproj
+++ b/Buildasaur.xcodeproj/project.pbxproj
@@ -84,7 +84,15 @@
 		3AD338B01AAE31D500ECD0F2 /* BuildTemplateViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3AD338AF1AAE31D500ECD0F2 /* BuildTemplateViewController.swift */; };
 		3AF090B81B1134AA0058567F /* BranchWatchingViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3AF090B71B1134AA0058567F /* BranchWatchingViewController.swift */; };
 		3AF1B1241AAC7CA500917EF3 /* StatusSyncerViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3AF1B1231AAC7CA500917EF3 /* StatusSyncerViewController.swift */; };
-		72C942865E06140723569CF1 /* Pods_Buildasaur.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = BFC5293812E0E442BE2182D0 /* Pods_Buildasaur.framework */; settings = {ATTRIBUTES = (Weak, ); }; };
+		4CA544161B8C054A002321B8 /* Pods_BuildaAnalytics.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 4CA544151B8C054A002321B8 /* Pods_BuildaAnalytics.framework */; settings = {ATTRIBUTES = (Weak, ); }; };
+		4CA544181B8C057A002321B8 /* BuildaAnalytics.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4CA544171B8C057A002321B8 /* BuildaAnalytics.swift */; };
+		4CA5441A1B8C0C10002321B8 /* BuildaAnalyticsEvents.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4CA544191B8C0C10002321B8 /* BuildaAnalyticsEvents.swift */; };
+		4CA9DD891B8C0498005330D7 /* BuildaAnalytics.h in Headers */ = {isa = PBXBuildFile; fileRef = 4CA9DD881B8C0498005330D7 /* BuildaAnalytics.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		4CA9DD901B8C0498005330D7 /* BuildaAnalytics.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 4CA9DD861B8C0498005330D7 /* BuildaAnalytics.framework */; };
+		4CA9DD971B8C0498005330D7 /* BuildaAnalyticsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4CA9DD961B8C0498005330D7 /* BuildaAnalyticsTests.swift */; };
+		4CA9DD9B1B8C0498005330D7 /* BuildaAnalytics.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 4CA9DD861B8C0498005330D7 /* BuildaAnalytics.framework */; };
+		4CA9DD9C1B8C0498005330D7 /* BuildaAnalytics.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 4CA9DD861B8C0498005330D7 /* BuildaAnalytics.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
+		72C942865E06140723569CF1 /* Pods_Buildasaur.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = BFC5293812E0E442BE2182D0 /* Pods_Buildasaur.framework */; settings = {ATTRIBUTES = (Required, ); }; };
 		B967DFBE36176FD9B4960410 /* Pods_BuildaGitServer.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 73C0D6A9CBF4A8155E3A7376 /* Pods_BuildaGitServer.framework */; settings = {ATTRIBUTES = (Weak, ); }; };
 		EC160F5DE92FC57D64786D8F /* Pods_BuildaKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 1086D69942F8B7830B5D00E1 /* Pods_BuildaKit.framework */; settings = {ATTRIBUTES = (Weak, ); }; };
 		F27BD0C6EA74D366E34EB3BA /* Pods_BuildaGitServerTests.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 9ECC1671A5C1E3811C3C3FFB /* Pods_BuildaGitServerTests.framework */; settings = {ATTRIBUTES = (Weak, ); }; };
@@ -140,6 +148,27 @@
 			remoteGlobalIDString = 3AAF6EE31A3CE5BA00C657FB;
 			remoteInfo = BuildaGitServer;
 		};
+		4CA9DD911B8C0498005330D7 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 3A5687681A3B93BD0066DB2B /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = 4CA9DD851B8C0498005330D7;
+			remoteInfo = BuildaAnalytics;
+		};
+		4CA9DD931B8C0498005330D7 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 3A5687681A3B93BD0066DB2B /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = 3A56876F1A3B93BD0066DB2B;
+			remoteInfo = Buildasaur;
+		};
+		4CA9DD991B8C0498005330D7 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 3A5687681A3B93BD0066DB2B /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = 4CA9DD851B8C0498005330D7;
+			remoteInfo = BuildaAnalytics;
+		};
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXCopyFilesBuildPhase section */
@@ -149,6 +178,7 @@
 			dstPath = "";
 			dstSubfolderSpec = 10;
 			files = (
+				4CA9DD9C1B8C0498005330D7 /* BuildaAnalytics.framework in Embed Frameworks */,
 				3AAF6EFC1A3CE5BA00C657FB /* BuildaGitServer.framework in Embed Frameworks */,
 				3A81BB2C1B5A77E9004732CD /* BuildaKit.framework in Embed Frameworks */,
 			);
@@ -167,6 +197,7 @@
 		2BA66B4A6DFD76C4122D696A /* Pods-BuildaUtils.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-BuildaUtils.debug.xcconfig"; path = "Pods/Target Support Files/Pods-BuildaUtils/Pods-BuildaUtils.debug.xcconfig"; sourceTree = "<group>"; };
 		2F8799E7CA29F40E308CB090 /* Pods-BuildaKit.testing.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-BuildaKit.testing.xcconfig"; path = "Pods/Target Support Files/Pods-BuildaKit/Pods-BuildaKit.testing.xcconfig"; sourceTree = "<group>"; };
 		367971821BC7964B03631774 /* Pods_BuildaUtils.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_BuildaUtils.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		39E648C4DC2199469616B58E /* Pods-BuildaAnalytics.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-BuildaAnalytics.release.xcconfig"; path = "Pods/Target Support Files/Pods-BuildaAnalytics/Pods-BuildaAnalytics.release.xcconfig"; sourceTree = "<group>"; };
 		3A3231B01B5AEF7900B53E3F /* Logging.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Logging.swift; sourceTree = "<group>"; };
 		3A32CD131A3D00F800861A34 /* Comment.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Comment.swift; sourceTree = "<group>"; };
 		3A32CD171A3D01E300861A34 /* Issue.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Issue.swift; sourceTree = "<group>"; };
@@ -250,6 +281,15 @@
 		40BCAC9716082AB3070E2DDC /* Pods_BuildaUtilsTests.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_BuildaUtilsTests.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		4B5DB9726CCDA0682B1C8D8A /* Pods-BuildaKitTests.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-BuildaKitTests.debug.xcconfig"; path = "Pods/Target Support Files/Pods-BuildaKitTests/Pods-BuildaKitTests.debug.xcconfig"; sourceTree = "<group>"; };
 		4C0A89C04EE4D1B92581E300 /* Pods-BuildaGitServer.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-BuildaGitServer.debug.xcconfig"; path = "Pods/Target Support Files/Pods-BuildaGitServer/Pods-BuildaGitServer.debug.xcconfig"; sourceTree = "<group>"; };
+		4CA544151B8C054A002321B8 /* Pods_BuildaAnalytics.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Pods_BuildaAnalytics.framework; path = Pods/../build/Debug/Pods_BuildaAnalytics.framework; sourceTree = "<group>"; };
+		4CA544171B8C057A002321B8 /* BuildaAnalytics.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = BuildaAnalytics.swift; sourceTree = "<group>"; };
+		4CA544191B8C0C10002321B8 /* BuildaAnalyticsEvents.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = BuildaAnalyticsEvents.swift; sourceTree = "<group>"; };
+		4CA9DD861B8C0498005330D7 /* BuildaAnalytics.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = BuildaAnalytics.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		4CA9DD881B8C0498005330D7 /* BuildaAnalytics.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = BuildaAnalytics.h; sourceTree = "<group>"; };
+		4CA9DD8A1B8C0498005330D7 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
+		4CA9DD8F1B8C0498005330D7 /* BuildaAnalyticsTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = BuildaAnalyticsTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
+		4CA9DD961B8C0498005330D7 /* BuildaAnalyticsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BuildaAnalyticsTests.swift; sourceTree = "<group>"; };
+		4CA9DD981B8C0498005330D7 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		5A1BF45FB90783C591B4D525 /* Pods-BuildaGitServer.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-BuildaGitServer.release.xcconfig"; path = "Pods/Target Support Files/Pods-BuildaGitServer/Pods-BuildaGitServer.release.xcconfig"; sourceTree = "<group>"; };
 		60565EAEB9A1817A1DEB0FF2 /* Pods-BuildaGitServerTests.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-BuildaGitServerTests.debug.xcconfig"; path = "Pods/Target Support Files/Pods-BuildaGitServerTests/Pods-BuildaGitServerTests.debug.xcconfig"; sourceTree = "<group>"; };
 		681D44417C140BD1795F71E4 /* Pods-BuildaGitServer.testing.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-BuildaGitServer.testing.xcconfig"; path = "Pods/Target Support Files/Pods-BuildaGitServer/Pods-BuildaGitServer.testing.xcconfig"; sourceTree = "<group>"; };
@@ -258,7 +298,9 @@
 		7C82BB415700C81EA9715FE4 /* Pods-Buildasaur.testing.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Buildasaur.testing.xcconfig"; path = "Pods/Target Support Files/Pods-Buildasaur/Pods-Buildasaur.testing.xcconfig"; sourceTree = "<group>"; };
 		7E934E50EA252648E6AFE307 /* Pods-BuildaKitTests.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-BuildaKitTests.release.xcconfig"; path = "Pods/Target Support Files/Pods-BuildaKitTests/Pods-BuildaKitTests.release.xcconfig"; sourceTree = "<group>"; };
 		812198AFEF9A93437DF9E7BF /* Pods-BuildaKit.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-BuildaKit.release.xcconfig"; path = "Pods/Target Support Files/Pods-BuildaKit/Pods-BuildaKit.release.xcconfig"; sourceTree = "<group>"; };
+		8FB01D270AB454D59D1B25CA /* Pods-BuildaAnalytics.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-BuildaAnalytics.debug.xcconfig"; path = "Pods/Target Support Files/Pods-BuildaAnalytics/Pods-BuildaAnalytics.debug.xcconfig"; sourceTree = "<group>"; };
 		9763FA72546E3CAF2D2786DA /* Pods_BuildaKitTests.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_BuildaKitTests.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		9AA4D5159F2652A25A9CC33B /* Pods-BuildaAnalytics.testing.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-BuildaAnalytics.testing.xcconfig"; path = "Pods/Target Support Files/Pods-BuildaAnalytics/Pods-BuildaAnalytics.testing.xcconfig"; sourceTree = "<group>"; };
 		9ECC1671A5C1E3811C3C3FFB /* Pods_BuildaGitServerTests.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_BuildaGitServerTests.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		9FD7CC3A9C814B53A3E59FEA /* Pods-BuildaGitServerTests.testing.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-BuildaGitServerTests.testing.xcconfig"; path = "Pods/Target Support Files/Pods-BuildaGitServerTests/Pods-BuildaGitServerTests.testing.xcconfig"; sourceTree = "<group>"; };
 		AD459625FF20E15478BB71A2 /* Pods-Buildasaur.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Buildasaur.debug.xcconfig"; path = "Pods/Target Support Files/Pods-Buildasaur/Pods-Buildasaur.debug.xcconfig"; sourceTree = "<group>"; };
@@ -268,6 +310,7 @@
 		C932019AC696395A2BF69F2F /* Pods-BuildaKit.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-BuildaKit.debug.xcconfig"; path = "Pods/Target Support Files/Pods-BuildaKit/Pods-BuildaKit.debug.xcconfig"; sourceTree = "<group>"; };
 		CECD9EDC0C4F882ACEB5E1F3 /* Pods-Buildasaur.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Buildasaur.release.xcconfig"; path = "Pods/Target Support Files/Pods-Buildasaur/Pods-Buildasaur.release.xcconfig"; sourceTree = "<group>"; };
 		DC54BBBDFD511913AA588726 /* Pods-BuildaUtilsTests.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-BuildaUtilsTests.release.xcconfig"; path = "Pods/Target Support Files/Pods-BuildaUtilsTests/Pods-BuildaUtilsTests.release.xcconfig"; sourceTree = "<group>"; };
+		ED2034509984340D073FD9A1 /* Pods_BuildaAnalytics.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_BuildaAnalytics.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		F159C5240A79DE46DB418D8C /* Pods-BuildaGitServerTests.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-BuildaGitServerTests.release.xcconfig"; path = "Pods/Target Support Files/Pods-BuildaGitServerTests/Pods-BuildaGitServerTests.release.xcconfig"; sourceTree = "<group>"; };
 		F55F8A6BBDE1F9BD198D441A /* Pods-BuildaUtilsTests.testing.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-BuildaUtilsTests.testing.xcconfig"; path = "Pods/Target Support Files/Pods-BuildaUtilsTests/Pods-BuildaUtilsTests.testing.xcconfig"; sourceTree = "<group>"; };
 /* End PBXFileReference section */
@@ -279,6 +322,7 @@
 			files = (
 				3A81BB2B1B5A77E9004732CD /* BuildaKit.framework in Frameworks */,
 				3AAF6EFB1A3CE5BA00C657FB /* BuildaGitServer.framework in Frameworks */,
+				4CA9DD9B1B8C0498005330D7 /* BuildaAnalytics.framework in Frameworks */,
 				72C942865E06140723569CF1 /* Pods_Buildasaur.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -318,6 +362,22 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
+		4CA9DD821B8C0498005330D7 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				4CA544161B8C054A002321B8 /* Pods_BuildaAnalytics.framework in Frameworks */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		4CA9DD8C1B8C0498005330D7 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				4CA9DD901B8C0498005330D7 /* BuildaAnalytics.framework in Frameworks */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 /* End PBXFrameworksBuildPhase section */
 
 /* Begin PBXGroup section */
@@ -348,6 +408,9 @@
 				4B5DB9726CCDA0682B1C8D8A /* Pods-BuildaKitTests.debug.xcconfig */,
 				C6866CD696AF52F4772D2C38 /* Pods-BuildaKitTests.testing.xcconfig */,
 				7E934E50EA252648E6AFE307 /* Pods-BuildaKitTests.release.xcconfig */,
+				8FB01D270AB454D59D1B25CA /* Pods-BuildaAnalytics.debug.xcconfig */,
+				9AA4D5159F2652A25A9CC33B /* Pods-BuildaAnalytics.testing.xcconfig */,
+				39E648C4DC2199469616B58E /* Pods-BuildaAnalytics.release.xcconfig */,
 			);
 			name = Pods;
 			sourceTree = "<group>";
@@ -360,6 +423,8 @@
 				3A81BB251B5A77E9004732CD /* BuildaKitTests */,
 				3AAF6EE51A3CE5BA00C657FB /* BuildaGitServer */,
 				3AAF6EF41A3CE5BA00C657FB /* BuildaGitServerTests */,
+				4CA9DD871B8C0498005330D7 /* BuildaAnalytics */,
+				4CA9DD951B8C0498005330D7 /* BuildaAnalyticsTests */,
 				3A5687711A3B93BD0066DB2B /* Products */,
 				00BB8425DD68675612C875AD /* Pods */,
 				50A74951EE20FE8714EAD98C /* Frameworks */,
@@ -374,6 +439,8 @@
 				3AAF6EEE1A3CE5BA00C657FB /* BuildaGitServerTests.xctest */,
 				3A81BB161B5A77E9004732CD /* BuildaKit.framework */,
 				3A81BB1F1B5A77E9004732CD /* BuildaKitTests.xctest */,
+				4CA9DD861B8C0498005330D7 /* BuildaAnalytics.framework */,
+				4CA9DD8F1B8C0498005330D7 /* BuildaAnalyticsTests.xctest */,
 			);
 			name = Products;
 			sourceTree = "<group>";
@@ -546,9 +613,30 @@
 			name = "Supporting Files";
 			sourceTree = "<group>";
 		};
+		4CA9DD871B8C0498005330D7 /* BuildaAnalytics */ = {
+			isa = PBXGroup;
+			children = (
+				4CA9DD881B8C0498005330D7 /* BuildaAnalytics.h */,
+				4CA9DD8A1B8C0498005330D7 /* Info.plist */,
+				4CA544171B8C057A002321B8 /* BuildaAnalytics.swift */,
+				4CA544191B8C0C10002321B8 /* BuildaAnalyticsEvents.swift */,
+			);
+			path = BuildaAnalytics;
+			sourceTree = "<group>";
+		};
+		4CA9DD951B8C0498005330D7 /* BuildaAnalyticsTests */ = {
+			isa = PBXGroup;
+			children = (
+				4CA9DD961B8C0498005330D7 /* BuildaAnalyticsTests.swift */,
+				4CA9DD981B8C0498005330D7 /* Info.plist */,
+			);
+			path = BuildaAnalyticsTests;
+			sourceTree = "<group>";
+		};
 		50A74951EE20FE8714EAD98C /* Frameworks */ = {
 			isa = PBXGroup;
 			children = (
+				4CA544151B8C054A002321B8 /* Pods_BuildaAnalytics.framework */,
 				367971821BC7964B03631774 /* Pods_BuildaUtils.framework */,
 				73C0D6A9CBF4A8155E3A7376 /* Pods_BuildaGitServer.framework */,
 				BFC5293812E0E442BE2182D0 /* Pods_Buildasaur.framework */,
@@ -557,6 +645,7 @@
 				40BCAC9716082AB3070E2DDC /* Pods_BuildaUtilsTests.framework */,
 				1086D69942F8B7830B5D00E1 /* Pods_BuildaKit.framework */,
 				9763FA72546E3CAF2D2786DA /* Pods_BuildaKitTests.framework */,
+				ED2034509984340D073FD9A1 /* Pods_BuildaAnalytics.framework */,
 			);
 			name = Frameworks;
 			sourceTree = "<group>";
@@ -580,6 +669,14 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
+		4CA9DD831B8C0498005330D7 /* Headers */ = {
+			isa = PBXHeadersBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				4CA9DD891B8C0498005330D7 /* BuildaAnalytics.h in Headers */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 /* End PBXHeadersBuildPhase section */
 
 /* Begin PBXNativeTarget section */
@@ -600,6 +697,7 @@
 			dependencies = (
 				3AAF6EFA1A3CE5BA00C657FB /* PBXTargetDependency */,
 				3A81BB2A1B5A77E9004732CD /* PBXTargetDependency */,
+				4CA9DD9A1B8C0498005330D7 /* PBXTargetDependency */,
 			);
 			name = Buildasaur;
 			productName = Buildasaur;
@@ -691,6 +789,45 @@
 			productReference = 3AAF6EEE1A3CE5BA00C657FB /* BuildaGitServerTests.xctest */;
 			productType = "com.apple.product-type.bundle.unit-test";
 		};
+		4CA9DD851B8C0498005330D7 /* BuildaAnalytics */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = 4CA9DD9D1B8C0498005330D7 /* Build configuration list for PBXNativeTarget "BuildaAnalytics" */;
+			buildPhases = (
+				AFA4EEF263BEE8B4772D0D60 /* Check Pods Manifest.lock */,
+				4CA9DD811B8C0498005330D7 /* Sources */,
+				4CA9DD821B8C0498005330D7 /* Frameworks */,
+				4CA9DD831B8C0498005330D7 /* Headers */,
+				4CA9DD841B8C0498005330D7 /* Resources */,
+				C77C0A0AEBC7628AC90CBC2F /* Copy Pods Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			name = BuildaAnalytics;
+			productName = BuildaAnalytics;
+			productReference = 4CA9DD861B8C0498005330D7 /* BuildaAnalytics.framework */;
+			productType = "com.apple.product-type.framework";
+		};
+		4CA9DD8E1B8C0498005330D7 /* BuildaAnalyticsTests */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = 4CA9DDA11B8C0498005330D7 /* Build configuration list for PBXNativeTarget "BuildaAnalyticsTests" */;
+			buildPhases = (
+				4CA9DD8B1B8C0498005330D7 /* Sources */,
+				4CA9DD8C1B8C0498005330D7 /* Frameworks */,
+				4CA9DD8D1B8C0498005330D7 /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+				4CA9DD921B8C0498005330D7 /* PBXTargetDependency */,
+				4CA9DD941B8C0498005330D7 /* PBXTargetDependency */,
+			);
+			name = BuildaAnalyticsTests;
+			productName = BuildaAnalyticsTests;
+			productReference = 4CA9DD8F1B8C0498005330D7 /* BuildaAnalyticsTests.xctest */;
+			productType = "com.apple.product-type.bundle.unit-test";
+		};
 /* End PBXNativeTarget section */
 
 /* Begin PBXProject section */
@@ -725,6 +862,14 @@
 						CreatedOnToolsVersion = 6.1.1;
 						TestTargetID = 3A56876F1A3B93BD0066DB2B;
 					};
+					4CA9DD851B8C0498005330D7 = {
+						CreatedOnToolsVersion = 7.0;
+						DevelopmentTeam = 7BJ2984YDK;
+					};
+					4CA9DD8E1B8C0498005330D7 = {
+						CreatedOnToolsVersion = 7.0;
+						TestTargetID = 3A56876F1A3B93BD0066DB2B;
+					};
 				};
 			};
 			buildConfigurationList = 3A56876B1A3B93BD0066DB2B /* Build configuration list for PBXProject "Buildasaur" */;
@@ -745,6 +890,8 @@
 				3A81BB1E1B5A77E9004732CD /* BuildaKitTests */,
 				3AAF6EE31A3CE5BA00C657FB /* BuildaGitServer */,
 				3AAF6EED1A3CE5BA00C657FB /* BuildaGitServerTests */,
+				4CA9DD851B8C0498005330D7 /* BuildaAnalytics */,
+				4CA9DD8E1B8C0498005330D7 /* BuildaAnalyticsTests */,
 			);
 		};
 /* End PBXProject section */
@@ -782,6 +929,20 @@
 			runOnlyForDeploymentPostprocessing = 0;
 		};
 		3AAF6EEC1A3CE5BA00C657FB /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		4CA9DD841B8C0498005330D7 /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		4CA9DD8D1B8C0498005330D7 /* Resources */ = {
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
@@ -924,6 +1085,36 @@
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
 			shellScript = "\"${SRCROOT}/Pods/Target Support Files/Pods-BuildaGitServerTests/Pods-BuildaGitServerTests-resources.sh\"\n";
+			showEnvVarsInLog = 0;
+		};
+		AFA4EEF263BEE8B4772D0D60 /* Check Pods Manifest.lock */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputPaths = (
+			);
+			name = "Check Pods Manifest.lock";
+			outputPaths = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "diff \"${PODS_ROOT}/../Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [[ $? != 0 ]] ; then\n    cat << EOM\nerror: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\nEOM\n    exit 1\nfi\n";
+			showEnvVarsInLog = 0;
+		};
+		C77C0A0AEBC7628AC90CBC2F /* Copy Pods Resources */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputPaths = (
+			);
+			name = "Copy Pods Resources";
+			outputPaths = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "\"${SRCROOT}/Pods/Target Support Files/Pods-BuildaAnalytics/Pods-BuildaAnalytics-resources.sh\"\n";
 			showEnvVarsInLog = 0;
 		};
 		D6B2FF7E0F016F08197E2719 /* Embed Pods Frameworks */ = {
@@ -1088,6 +1279,23 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
+		4CA9DD811B8C0498005330D7 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				4CA5441A1B8C0C10002321B8 /* BuildaAnalyticsEvents.swift in Sources */,
+				4CA544181B8C057A002321B8 /* BuildaAnalytics.swift in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		4CA9DD8B1B8C0498005330D7 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				4CA9DD971B8C0498005330D7 /* BuildaAnalyticsTests.swift in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 /* End PBXSourcesBuildPhase section */
 
 /* Begin PBXTargetDependency section */
@@ -1125,6 +1333,21 @@
 			isa = PBXTargetDependency;
 			target = 3AAF6EE31A3CE5BA00C657FB /* BuildaGitServer */;
 			targetProxy = 3AAF6EF91A3CE5BA00C657FB /* PBXContainerItemProxy */;
+		};
+		4CA9DD921B8C0498005330D7 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = 4CA9DD851B8C0498005330D7 /* BuildaAnalytics */;
+			targetProxy = 4CA9DD911B8C0498005330D7 /* PBXContainerItemProxy */;
+		};
+		4CA9DD941B8C0498005330D7 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = 3A56876F1A3B93BD0066DB2B /* Buildasaur */;
+			targetProxy = 4CA9DD931B8C0498005330D7 /* PBXContainerItemProxy */;
+		};
+		4CA9DD9A1B8C0498005330D7 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = 4CA9DD851B8C0498005330D7 /* BuildaAnalytics */;
+			targetProxy = 4CA9DD991B8C0498005330D7 /* PBXContainerItemProxy */;
 		};
 /* End PBXTargetDependency section */
 
@@ -1578,6 +1801,141 @@
 			};
 			name = Release;
 		};
+		4CA9DD9E1B8C0498005330D7 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			baseConfigurationReference = 8FB01D270AB454D59D1B25CA /* Pods-BuildaAnalytics.debug.xcconfig */;
+			buildSettings = {
+				CLANG_ENABLE_MODULES = YES;
+				COMBINE_HIDPI_IMAGES = YES;
+				CURRENT_PROJECT_VERSION = 1;
+				DEFINES_MODULE = YES;
+				DYLIB_COMPATIBILITY_VERSION = 1;
+				DYLIB_CURRENT_VERSION = 1;
+				DYLIB_INSTALL_NAME_BASE = "@rpath";
+				FRAMEWORK_SEARCH_PATHS = (
+					"$(inherited)",
+					"$(PROJECT_DIR)/build/Debug",
+				);
+				FRAMEWORK_VERSION = A;
+				GCC_NO_COMMON_BLOCKS = YES;
+				INFOPLIST_FILE = BuildaAnalytics/Info.plist;
+				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/../Frameworks @loader_path/Frameworks";
+				PRODUCT_BUNDLE_IDENTIFIER = com.honzadvorsky.BuildaAnalytics;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SKIP_INSTALL = YES;
+				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
+				VERSIONING_SYSTEM = "apple-generic";
+				VERSION_INFO_PREFIX = "";
+			};
+			name = Debug;
+		};
+		4CA9DD9F1B8C0498005330D7 /* Testing */ = {
+			isa = XCBuildConfiguration;
+			baseConfigurationReference = 9AA4D5159F2652A25A9CC33B /* Pods-BuildaAnalytics.testing.xcconfig */;
+			buildSettings = {
+				CLANG_ENABLE_MODULES = YES;
+				COMBINE_HIDPI_IMAGES = YES;
+				COPY_PHASE_STRIP = NO;
+				CURRENT_PROJECT_VERSION = 1;
+				DEFINES_MODULE = YES;
+				DYLIB_COMPATIBILITY_VERSION = 1;
+				DYLIB_CURRENT_VERSION = 1;
+				DYLIB_INSTALL_NAME_BASE = "@rpath";
+				ENABLE_NS_ASSERTIONS = NO;
+				FRAMEWORK_SEARCH_PATHS = (
+					"$(inherited)",
+					"$(PROJECT_DIR)/build/Debug",
+				);
+				FRAMEWORK_VERSION = A;
+				GCC_NO_COMMON_BLOCKS = YES;
+				INFOPLIST_FILE = BuildaAnalytics/Info.plist;
+				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/../Frameworks @loader_path/Frameworks";
+				PRODUCT_BUNDLE_IDENTIFIER = com.honzadvorsky.BuildaAnalytics;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SKIP_INSTALL = YES;
+				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
+				VERSIONING_SYSTEM = "apple-generic";
+				VERSION_INFO_PREFIX = "";
+			};
+			name = Testing;
+		};
+		4CA9DDA01B8C0498005330D7 /* Release */ = {
+			isa = XCBuildConfiguration;
+			baseConfigurationReference = 39E648C4DC2199469616B58E /* Pods-BuildaAnalytics.release.xcconfig */;
+			buildSettings = {
+				CLANG_ENABLE_MODULES = YES;
+				CODE_SIGN_IDENTITY = "Developer ID Application";
+				COMBINE_HIDPI_IMAGES = YES;
+				COPY_PHASE_STRIP = NO;
+				CURRENT_PROJECT_VERSION = 1;
+				DEFINES_MODULE = YES;
+				DYLIB_COMPATIBILITY_VERSION = 1;
+				DYLIB_CURRENT_VERSION = 1;
+				DYLIB_INSTALL_NAME_BASE = "@rpath";
+				ENABLE_NS_ASSERTIONS = NO;
+				FRAMEWORK_SEARCH_PATHS = (
+					"$(inherited)",
+					"$(PROJECT_DIR)/build/Debug",
+				);
+				FRAMEWORK_VERSION = A;
+				GCC_NO_COMMON_BLOCKS = YES;
+				INFOPLIST_FILE = BuildaAnalytics/Info.plist;
+				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/../Frameworks @loader_path/Frameworks";
+				PRODUCT_BUNDLE_IDENTIFIER = com.honzadvorsky.BuildaAnalytics;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SKIP_INSTALL = YES;
+				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
+				VERSIONING_SYSTEM = "apple-generic";
+				VERSION_INFO_PREFIX = "";
+			};
+			name = Release;
+		};
+		4CA9DDA21B8C0498005330D7 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				COMBINE_HIDPI_IMAGES = YES;
+				GCC_NO_COMMON_BLOCKS = YES;
+				INFOPLIST_FILE = BuildaAnalyticsTests/Info.plist;
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/../Frameworks @loader_path/../Frameworks";
+				PRODUCT_BUNDLE_IDENTIFIER = com.honzadvorsky.BuildaAnalyticsTests;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/Buildasaur.app/Contents/MacOS/Buildasaur";
+			};
+			name = Debug;
+		};
+		4CA9DDA31B8C0498005330D7 /* Testing */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				COMBINE_HIDPI_IMAGES = YES;
+				COPY_PHASE_STRIP = NO;
+				ENABLE_NS_ASSERTIONS = NO;
+				GCC_NO_COMMON_BLOCKS = YES;
+				INFOPLIST_FILE = BuildaAnalyticsTests/Info.plist;
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/../Frameworks @loader_path/../Frameworks";
+				PRODUCT_BUNDLE_IDENTIFIER = com.honzadvorsky.BuildaAnalyticsTests;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/Buildasaur.app/Contents/MacOS/Buildasaur";
+			};
+			name = Testing;
+		};
+		4CA9DDA41B8C0498005330D7 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				COMBINE_HIDPI_IMAGES = YES;
+				COPY_PHASE_STRIP = NO;
+				ENABLE_NS_ASSERTIONS = NO;
+				GCC_NO_COMMON_BLOCKS = YES;
+				INFOPLIST_FILE = BuildaAnalyticsTests/Info.plist;
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/../Frameworks @loader_path/../Frameworks";
+				PRODUCT_BUNDLE_IDENTIFIER = com.honzadvorsky.BuildaAnalyticsTests;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/Buildasaur.app/Contents/MacOS/Buildasaur";
+			};
+			name = Release;
+		};
 /* End XCBuildConfiguration section */
 
 /* Begin XCConfigurationList section */
@@ -1637,6 +1995,26 @@
 				3AAF6F011A3CE5BA00C657FB /* Debug */,
 				3A7A079D1AAB1524008C3425 /* Testing */,
 				3AAF6F021A3CE5BA00C657FB /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		4CA9DD9D1B8C0498005330D7 /* Build configuration list for PBXNativeTarget "BuildaAnalytics" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				4CA9DD9E1B8C0498005330D7 /* Debug */,
+				4CA9DD9F1B8C0498005330D7 /* Testing */,
+				4CA9DDA01B8C0498005330D7 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		4CA9DDA11B8C0498005330D7 /* Build configuration list for PBXNativeTarget "BuildaAnalyticsTests" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				4CA9DDA21B8C0498005330D7 /* Debug */,
+				4CA9DDA31B8C0498005330D7 /* Testing */,
+				4CA9DDA41B8C0498005330D7 /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;

--- a/Buildasaur.xcodeproj/xcshareddata/xcschemes/Buildasaur.xcscheme
+++ b/Buildasaur.xcodeproj/xcshareddata/xcschemes/Buildasaur.xcscheme
@@ -183,6 +183,16 @@
                ReferencedContainer = "container:Buildasaur.xcodeproj">
             </BuildableReference>
          </TestableReference>
+         <TestableReference
+            skipped = "NO">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "4CA9DD8E1B8C0498005330D7"
+               BuildableName = "BuildaAnalyticsTests.xctest"
+               BlueprintName = "BuildaAnalyticsTests"
+               ReferencedContainer = "container:Buildasaur.xcodeproj">
+            </BuildableReference>
+         </TestableReference>
       </Testables>
       <MacroExpansion>
          <BuildableReference

--- a/Buildasaur/AppDelegate.swift
+++ b/Buildasaur/AppDelegate.swift
@@ -17,6 +17,7 @@ Also, you can find the log at ~/Library/Application Support/Buildasaur/Builda.lo
 import BuildaUtils
 import XcodeServerSDK
 import BuildaKit
+import BuildaAnalytics
 
 @NSApplicationMain
 class AppDelegate: NSObject, NSApplicationDelegate {
@@ -24,9 +25,12 @@ class AppDelegate: NSObject, NSApplicationDelegate {
     let menuItemManager = MenuItemManager()
     
     func applicationDidFinishLaunching(aNotification: NSNotification) {
-        
+
         Logging.setup(alsoIntoFile: true)
         self.menuItemManager.setupMenuBarItem()
+        
+        let analytics = BuildaAnalytics.sharedInstance
+        analytics.fireAnalyticsEvent(BuildaAnalyticsEvent(funnel: .Feature, event: FeatureAnalyticsEvent.OpenApp))
     }
 
     func applicationShouldHandleReopen(sender: NSApplication, hasVisibleWindows flag: Bool) -> Bool {

--- a/Podfile
+++ b/Podfile
@@ -5,6 +5,10 @@ def pods_for_errbody
 	pod 'BuildaUtils', '0.0.11'
 end
 
+def pods_for_analytics
+	pod 'Tapstream', '2.9.5'
+end
+
 def also_xcode_pods
 	pods_for_errbody
 	pod 'XcodeServerSDK', '0.1.10'
@@ -30,5 +34,6 @@ target 'BuildaGitServerTests' do
 	pods_for_errbody
 end
 
-
-
+target 'BuildaAnalytics' do
+	pods_for_analytics
+end


### PR DESCRIPTION
#### Work Completed
- Update Podfile to include Tapstream SDK and target BuildaAnalytics.
- Add Tapstream dictionary keys to BuildaAnalytics info.plist.
- Stub analytics and funnels enumerations.
- Implement method to capture user analytics with no personal identifying information.
- Add Analytics tests
- Add Analytics example in App Delegate
- Add Podfile.lock to .gitignore
- Test implementation works
#### Notes
- Tapstream offers free analytics but has a limit of 10k DAU for free accounts. 
  - A different analytics platform could easily be swapped as we abstract the analytics SDK away from the main application in the new framework BuildaAnalytics.
  - Might be necessary to investigate different analytics platforms prior to integrating into the application.
- I've included enums for what I think are logical segments or funnels of different types of events, and have included an example of use in Buildasaur's AppDelegate.
  - Feel free to comment here on what types of events you'd like to track and I will implement them.
- Any user identifying information is not tracked, and Tapstream's default user tracking has been disabled. However to track usage I have created a unique and anonymous identifier that will be user specific.
