### PR TITLE
Refactored loading of checkout file, added support for xcscmblueprint file

### DIFF
--- a/BuildaKit/HDGitHubXCBotSyncer.swift
+++ b/BuildaKit/HDGitHubXCBotSyncer.swift
@@ -214,9 +214,9 @@ public class HDGitHubXCBotSyncer : Syncer {
     
     public func syncPRsAndBranchesAndBots(repo repo: Repo, repoName: String, prs: [PullRequest], branches: [Branch], bots: [Bot], completion: () -> ()) {
         
-        let prsDescription = prs.map({ "\n\tPR \($0.number): \($0.title) [\($0.head.ref) -> \($0.base.ref)]" }) + ["\n"]
-        let branchesDescription = branches.map({ "\n\tBranch [\($0.name):\($0.commit.sha)]" }) + ["\n"]
-        let botsDescription = bots.map({ "\n\tBot \($0.name)" }) + ["\n"]
+        let prsDescription = prs.map({ "    PR \($0.number): \($0.title) [\($0.head.ref) -> \($0.base.ref)]" }).joinWithSeparator("\n")
+        let branchesDescription = branches.map({ "    Branch [\($0.name):\($0.commit.sha)]" }).joinWithSeparator("\n")
+        let botsDescription = bots.map({ "    Bot \($0.name)" }).joinWithSeparator("\n")
         Log.verbose("Resolving prs:\n\(prsDescription) \nand branches:\n\(branchesDescription)\nand bots:\n\(botsDescription)")
         
         //create the changes necessary

--- a/BuildaKit/Project.swift
+++ b/BuildaKit/Project.swift
@@ -12,13 +12,6 @@ import XcodeServerSDK
 
 public class Project : JSONSerializable {
     
-    public enum AllowedCheckoutTypes: String {
-        case SSH = "SSH"
-//        case HTTPS - not yet supported, right now only SSH is supported
-//        (for bots reasons, will be built in when I have time)
-//        case SVN - not yet supported yet
-    }
-    
     public var url: NSURL {
         didSet {
             do { try self.refreshMetadata() } catch {}
@@ -35,68 +28,10 @@ public class Project : JSONSerializable {
     
     public var availabilityState: AvailabilityCheckState
     
-    private(set) var workspaceMetadata: NSDictionary?
-    let forkOriginURL: String?
-    
-    //convenience getters
-    public var projectName: String? { get { return self.pullValueForKey("IDESourceControlProjectName") }}
-    public var projectPath: String? { get { return self.pullValueForKey("IDESourceControlProjectPath") }}
-    public var projectWCCIdentifier: String? { get { return self.pullValueForKey("IDESourceControlProjectWCCIdentifier") }}
-    public var projectWCCName: String? {
-        get {
-            if let wccId = self.projectWCCIdentifier {
-                if let wcConfigs = self.workspaceMetadata?["IDESourceControlProjectWCConfigurations"] as? [NSDictionary] {
-                    if let foundConfig = wcConfigs.filter({
-                        if let loopWccId = $0.optionalStringForKey("IDESourceControlWCCIdentifierKey") {
-                            return loopWccId == wccId
-                        }
-                        return false
-                    }).first {
-                        //so much effort for this little key...
-                        return foundConfig.optionalStringForKey("IDESourceControlWCCName")
-                    }
-                }
-            }
-            return nil
-        }
-    }
-    public var projectURL: NSURL? {
-        get {
-            if let urlString = self.pullValueForKey("IDESourceControlProjectURL") {
-                
-                //if we have a fork, chose its URL, otherwise fallback to the loaded URL from the Checkout file
-                var finalUrlString = self.forkOriginURL ?? urlString
-                let type = self.checkoutType!
-                if type == .SSH {
-                    if !finalUrlString.hasPrefix("git@") {
-                        finalUrlString = "git@\(finalUrlString)"
-                    }
-                }
-
-                return NSURL(string: finalUrlString)
-            }
-            return nil
-        }
-    }
-    
-    public var checkoutType: AllowedCheckoutTypes? {
-        get {
-            if
-                let meta = self.workspaceMetadata,
-                let type = Project.parseCheckoutType(meta) {
-                    return type
-            }
-            return nil
-        }
-    }
-
-    private func pullValueForKey(key: String) -> String? {
-        return self.workspaceMetadata?.optionalStringForKey(key)
-    }
+    private(set) public var workspaceMetadata: WorkspaceMetadata?
     
     public init?(url: NSURL) {
         
-        self.forkOriginURL = nil
         self.url = url
         self.preferredTemplateId = nil
         self.githubToken = nil
@@ -112,9 +47,8 @@ public class Project : JSONSerializable {
         }
     }
     
-    private init?(original: Project, forkOriginURL: String) {
+    private init(original: Project, forkOriginURL: String) throws {
         
-        self.forkOriginURL = forkOriginURL
         self.url = original.url
         self.preferredTemplateId = original.preferredTemplateId
         self.githubToken = original.githubToken
@@ -122,71 +56,24 @@ public class Project : JSONSerializable {
         self.publicSSHKeyUrl = original.publicSSHKeyUrl
         self.privateSSHKeyUrl = original.privateSSHKeyUrl
         self.sshPassphrase = original.sshPassphrase
-        do {
-            try self.refreshMetadata()
-        } catch {
-            Log.error(error)
-            return nil
-        }
+        self.workspaceMetadata = try original.workspaceMetadata?.duplicateWithForkURL(forkOriginURL)
     }
     
-    public func duplicateForForkAtOriginURL(forkURL: String) -> Project? {
-        
-        return Project(original: self, forkOriginURL: forkURL)
+    public func duplicateForForkAtOriginURL(forkURL: String) throws -> Project {
+        return try Project(original: self, forkOriginURL: forkURL)
     }
     
-    public class func attemptToParseFromUrl(url: NSURL) throws -> NSDictionary {
-        
-        let meta = try Project.loadWorkspaceMetadata(url)
-        
-        //validate allowed remote url
-        if self.parseCheckoutType(meta) == nil {
-            //disallowed
-            let allowedString = [AllowedCheckoutTypes.SSH].map({ $0.rawValue }).joinWithSeparator(", ")
-            let error = Error.withInfo("Disallowed checkout type, the project must be checked out over one of the supported schemes: \(allowedString)")
-            throw error
-        }
-        
-        return meta
-    }
-    
-    private class func parseCheckoutType(metadata: NSDictionary) -> AllowedCheckoutTypes? {
-        
-        if
-            let urlString = metadata.optionalStringForKey("IDESourceControlProjectURL"),
-            let url = NSURL(string: urlString)
-        {
-            let scheme = url.scheme
-            switch scheme {
-            case "github.com":
-                return AllowedCheckoutTypes.SSH
-            case "https":
-                
-                if urlString.hasSuffix(".git") {
-                    //HTTPS git
-                } else {
-                    //SVN
-                }
-                
-                Log.error("HTTPS or SVN not yet supported, please create an issue on GitHub if you want it added (czechboy0/Buildasaur)")
-                return nil
-            default:
-                return nil
-            }
-        } else {
-            return nil
-        }
+    public class func attemptToParseFromUrl(url: NSURL) throws -> WorkspaceMetadata {
+        return try Project.loadWorkspaceMetadata(url)
     }
 
     private func refreshMetadata() throws {
-        
         let meta = try Project.attemptToParseFromUrl(self.url)
         self.workspaceMetadata = meta
     }
     
     public required init?(json: NSDictionary) {
         
-        self.forkOriginURL = nil
         self.availabilityState = .Unchecked
         
         if
@@ -224,12 +111,12 @@ public class Project : JSONSerializable {
             self.publicSSHKeyUrl = nil
             self.privateSSHKeyUrl = nil
             self.sshPassphrase = nil
+            self.workspaceMetadata = nil
             return nil
         }
     }
     
     public init() {
-        self.forkOriginURL = nil
         self.availabilityState = .Unchecked
         self.url = NSURL()
         self.preferredTemplateId = nil
@@ -237,6 +124,7 @@ public class Project : JSONSerializable {
         self.publicSSHKeyUrl = nil
         self.privateSSHKeyUrl = nil
         self.sshPassphrase = nil
+        self.workspaceMetadata = nil
     }
     
     public func jsonify() -> NSDictionary {
@@ -260,14 +148,14 @@ public class Project : JSONSerializable {
         return names
     }
     
-    private class func loadWorkspaceMetadata(url: NSURL) throws -> NSDictionary {
+    private class func loadWorkspaceMetadata(url: NSURL) throws -> WorkspaceMetadata {
         
         return try XcodeProjectParser.parseRepoMetadataFromProjectOrWorkspaceURL(url)
     }
     
     public func githubRepoName() -> String? {
         
-        if let projectUrl = self.projectURL {
+        if let projectUrl = self.workspaceMetadata?.projectURL {
             let originalStringUrl = projectUrl.absoluteString
             let stringUrl = originalStringUrl.lowercaseString
             

--- a/BuildaKit/SourceControlFileParser.swift
+++ b/BuildaKit/SourceControlFileParser.swift
@@ -59,7 +59,40 @@ class BlueprintFileParser: SourceControlFileParser {
     }
     
     func parseFileAtUrl(url: NSURL) throws -> WorkspaceMetadata {
-        throw Error.withInfo("Not yet supported")
+
+        //JSON -> NSDictionary
+        let data = try NSData(contentsOfURL: url, options: NSDataReadingOptions())
+        let jsonObject = try NSJSONSerialization.JSONObjectWithData(data, options: NSJSONReadingOptions())
+        guard let dictionary = jsonObject as? NSDictionary else { throw Error.withInfo("Failed to parse \(url)") }
+
+        //parse our required keys
+        let projectName = dictionary.optionalStringForKey("DVTSourceControlWorkspaceBlueprintNameKey")
+        let projectPath = dictionary.optionalStringForKey("DVTSourceControlWorkspaceBlueprintRelativePathToProjectKey")
+        let projectWCCIdentifier = dictionary.optionalStringForKey("DVTSourceControlWorkspaceBlueprintPrimaryRemoteRepositoryKey")
+        
+        var primaryRemoteRepositoryDictionary: NSDictionary?
+        if let wccId = projectWCCIdentifier {
+            if let wcConfigs = dictionary["DVTSourceControlWorkspaceBlueprintRemoteRepositoriesKey"] as? [NSDictionary] {
+                primaryRemoteRepositoryDictionary = wcConfigs.filter({
+                    if let loopWccId = $0.optionalStringForKey("DVTSourceControlWorkspaceBlueprintRemoteRepositoryIdentifierKey") {
+                        return loopWccId == wccId
+                    }
+                    return false
+                }).first
+            }
+        }
+        
+        let projectURLString = primaryRemoteRepositoryDictionary?.optionalStringForKey("DVTSourceControlWorkspaceBlueprintRemoteRepositoryURLKey")
+        
+        var projectWCCName: String?
+        if
+            let copyPaths = dictionary["DVTSourceControlWorkspaceBlueprintWorkingCopyPathsKey"] as? [String: String],
+            let primaryRemoteRepoId = projectWCCIdentifier
+        {
+            projectWCCName = copyPaths[primaryRemoteRepoId]
+        }
+        
+        return try WorkspaceMetadata(projectName: projectName, projectPath: projectPath, projectWCCIdentifier: projectWCCIdentifier, projectWCCName: projectWCCName, projectURLString: projectURLString)
     }
 }
 

--- a/BuildaKit/SourceControlFileParser.swift
+++ b/BuildaKit/SourceControlFileParser.swift
@@ -1,0 +1,70 @@
+//
+//  SourceControlFileParser.swift
+//  Buildasaur
+//
+//  Created by Honza Dvorsky on 29/09/2015.
+//  Copyright © 2015 Honza Dvorsky. All rights reserved.
+//
+
+import Foundation
+import BuildaUtils
+
+protocol SourceControlFileParser {
+
+    func supportedFileExtensions() -> [String]
+    func parseFileAtUrl(url: NSURL) throws -> WorkspaceMetadata
+}
+
+class CheckoutFileParser: SourceControlFileParser {
+    
+    func supportedFileExtensions() -> [String] {
+        return ["xccheckout"]
+    }
+    
+    func parseFileAtUrl(url: NSURL) throws -> WorkspaceMetadata {
+        
+        //plist -> NSDictionary
+        guard let dictionary = NSDictionary(contentsOfURL: url) else { throw Error.withInfo("Failed to parse \(url)") }
+        
+        //parse our required keys
+        let projectName = dictionary.optionalStringForKey("IDESourceControlProjectName")
+        let projectPath = dictionary.optionalStringForKey("IDESourceControlProjectPath")
+        let projectWCCIdentifier = dictionary.optionalStringForKey("IDESourceControlProjectWCCIdentifier")
+        let projectWCCName = { () -> String? in
+            if let wccId = projectWCCIdentifier {
+                if let wcConfigs = dictionary["IDESourceControlProjectWCConfigurations"] as? [NSDictionary] {
+                    if let foundConfig = wcConfigs.filter({
+                        if let loopWccId = $0.optionalStringForKey("IDESourceControlWCCIdentifierKey") {
+                            return loopWccId == wccId
+                        }
+                        return false
+                    }).first {
+                        //so much effort for this little key...
+                        return foundConfig.optionalStringForKey("IDESourceControlWCCName")
+                    }
+                }
+            }
+            return nil
+            }()
+        let projectURL = { () -> NSURL? in
+            if let urlString = dictionary.optionalStringForKey("IDESourceControlProjectURL") {
+                return NSURL(string: urlString)
+            }
+            return nil
+            }()
+        
+        return try WorkspaceMetadata(projectName: projectName, projectPath: projectPath, projectWCCIdentifier: projectWCCIdentifier, projectWCCName: projectWCCName, projectURL: projectURL)
+    }
+}
+
+class BlueprintFileParser: SourceControlFileParser {
+    
+    func supportedFileExtensions() -> [String] {
+        return ["xcscmblueprint"]
+    }
+    
+    func parseFileAtUrl(url: NSURL) throws -> WorkspaceMetadata {
+        throw Error.withInfo("Not yet supported")
+    }
+}
+

--- a/BuildaKit/SourceControlFileParser.swift
+++ b/BuildaKit/SourceControlFileParser.swift
@@ -46,14 +46,9 @@ class CheckoutFileParser: SourceControlFileParser {
             }
             return nil
             }()
-        let projectURL = { () -> NSURL? in
-            if let urlString = dictionary.optionalStringForKey("IDESourceControlProjectURL") {
-                return NSURL(string: urlString)
-            }
-            return nil
-            }()
+        let projectURLString = { dictionary.optionalStringForKey("IDESourceControlProjectURL") }()
         
-        return try WorkspaceMetadata(projectName: projectName, projectPath: projectPath, projectWCCIdentifier: projectWCCIdentifier, projectWCCName: projectWCCName, projectURL: projectURL)
+        return try WorkspaceMetadata(projectName: projectName, projectPath: projectPath, projectWCCIdentifier: projectWCCIdentifier, projectWCCName: projectWCCName, projectURLString: projectURLString)
     }
 }
 

--- a/BuildaKit/SyncerBotManipulation.swift
+++ b/BuildaKit/SyncerBotManipulation.swift
@@ -60,16 +60,17 @@ extension HDGitHubXCBotSyncer {
         
         //to handle forks
         let headOriginUrl = repo.repoUrlSSH
-        let localProjectOriginUrl = self.project.projectURL!.absoluteString
+        let localProjectOriginUrl = self.project.workspaceMetadata!.projectURL.absoluteString
         
         let project: Project
         if headOriginUrl != localProjectOriginUrl {
             
             //we have a fork, duplicate the metadata with the fork's origin
-            if let source = self.project.duplicateForForkAtOriginURL(headOriginUrl) {
+            do {
+                let source = try self.project.duplicateForForkAtOriginURL(headOriginUrl)
                 project = source
-            } else {
-                self.notifyError(Error.withInfo("Couldn't create a Project for fork with origin at url \(headOriginUrl)"), context: "Creating a bot from a PR")
+            } catch {
+                self.notifyError(Error.withInfo("Couldn't create a Project for fork with origin at url \(headOriginUrl), error \(error)"), context: "Creating a bot from a PR")
                 completion()
                 return
             }

--- a/BuildaKit/WorkspaceMetadata.swift
+++ b/BuildaKit/WorkspaceMetadata.swift
@@ -1,0 +1,79 @@
+//
+//  WorkspaceMetadata.swift
+//  Buildasaur
+//
+//  Created by Honza Dvorsky on 29/09/2015.
+//  Copyright © 2015 Honza Dvorsky. All rights reserved.
+//
+
+import Foundation
+import BuildaUtils
+
+public enum CheckoutType: String {
+    case SSH = "SSH"
+    //        case HTTPS - not yet supported, right now only SSH is supported
+    //        (for bots reasons, will be built in when I have time)
+    //        case SVN - not yet supported yet
+}
+
+public struct WorkspaceMetadata {
+    
+    public let projectName: String
+    public let projectPath: String
+    public let projectWCCIdentifier: String
+    public let projectWCCName: String
+    public let projectURL: NSURL
+    public let checkoutType: CheckoutType
+    
+    init(projectName: String?, projectPath: String?, projectWCCIdentifier: String?, projectWCCName: String?, projectURL: NSURL?) throws {
+        
+        let errorForMissingKey: (String) -> ErrorType = { Error.withInfo("Can't find/parse \"\($0)\" in workspace metadata!") }
+        guard let projectName = projectName else { throw errorForMissingKey("Project Name") }
+        guard let projectPath = projectPath else { throw errorForMissingKey("Project Path") }
+        guard let projectWCCIdentifier = projectWCCIdentifier else { throw errorForMissingKey("Project WCC Identifier") }
+        guard let projectWCCName = projectWCCName else { throw errorForMissingKey("Project WCC Name") }
+        guard let projectURL = projectURL else { throw errorForMissingKey("Project URL") }
+        guard let checkoutType = WorkspaceMetadata.parseCheckoutType(projectURL) else {
+            let allowedString = [CheckoutType.SSH].map({ $0.rawValue }).joinWithSeparator(", ")
+            let error = Error.withInfo("Disallowed checkout type, the project must be checked out over one of the supported schemes: \(allowedString)")
+            throw error
+        }
+        
+        self.projectName = projectName
+        self.projectPath = projectPath
+        self.projectWCCIdentifier = projectWCCIdentifier
+        self.projectWCCName = projectWCCName
+        self.projectURL = projectURL
+        self.checkoutType = checkoutType
+    }
+    
+    func duplicateWithForkURL(forkUrlString: String?) throws -> WorkspaceMetadata {
+        let forkUrl = NSURL(string: forkUrlString ?? "")
+        return try WorkspaceMetadata(projectName: self.projectName, projectPath: self.projectPath, projectWCCIdentifier: self.projectWCCIdentifier, projectWCCName: self.projectWCCName, projectURL: forkUrl)
+    }
+}
+
+extension WorkspaceMetadata {
+    
+    internal static func parseCheckoutType(projectURL: NSURL) -> CheckoutType? {
+        
+        let urlString = projectURL.absoluteString
+        let scheme = projectURL.scheme
+        switch scheme {
+        case "github.com":
+            return CheckoutType.SSH
+        case "https":
+            
+            if urlString.hasSuffix(".git") {
+                //HTTPS git
+            } else {
+                //SVN
+            }
+            
+            Log.error("HTTPS or SVN not yet supported, please create an issue on GitHub if you want it added (czechboy0/Buildasaur)")
+            return nil
+        default:
+            return nil
+        }
+    }
+}

--- a/BuildaKit/XcodeProject.swift
+++ b/BuildaKit/XcodeProject.swift
@@ -13,11 +13,13 @@ extension Project {
     
     public func createSourceControlBlueprint(branch: String) -> SourceControlBlueprint {
         
-        let projectWCCIdentifier = self.projectWCCIdentifier!
-        let wccName = self.projectWCCName!
-        let projectName = self.projectName!
-        let projectURL = self.projectURL!.absoluteString
-        let projectPath = self.projectPath!
+        let workspaceMetadata = self.workspaceMetadata!
+        
+        let projectWCCIdentifier = workspaceMetadata.projectWCCIdentifier
+        let wccName = workspaceMetadata.projectWCCName
+        let projectName = workspaceMetadata.projectName
+        let projectURL = workspaceMetadata.projectURL.absoluteString
+        let projectPath = workspaceMetadata.projectPath
         let publicSSHKey = self.publicSSHKey
         let privateSSHKey = self.privateSSHKey
         let sshPassphrase = self.sshPassphrase
@@ -28,7 +30,7 @@ extension Project {
     
     public func createSourceControlBlueprintForCredentialVerification() -> SourceControlBlueprint {
         
-        let projectURL = self.projectURL!.absoluteString
+        let projectURL = self.workspaceMetadata!.projectURL.absoluteString
         let publicSSHKey = self.publicSSHKey
         let privateSSHKey = self.privateSSHKey
         let sshPassphrase = self.sshPassphrase

--- a/BuildaKit/XcodeProjectParser.swift
+++ b/BuildaKit/XcodeProjectParser.swift
@@ -91,7 +91,7 @@ public class XcodeProjectParser {
             let parsed = try self.parseCheckoutOrBlueprintFile(checkoutUrl)
             return parsed
         } catch {
-            throw Error.withInfo("Cannot find the Checkout/Blueprint file, please make sure to open this project in Xcode at least once (it will generate the required Checkout/Blueprint file) and create at least one Bot from Xcode. Then please try again. Create an issue on GitHub is this issue persists.")
+            throw Error.withInfo("Cannot find the Checkout/Blueprint file, please make sure to open this project in Xcode at least once (it will generate the required Checkout/Blueprint file) and create at least one Bot from Xcode. Then please try again. Create an issue on GitHub is this issue persists. (Error \((error as NSError).localizedDescription))")
         }
     }
     

--- a/BuildaKit/XcodeProjectParser.swift
+++ b/BuildaKit/XcodeProjectParser.swift
@@ -11,6 +11,11 @@ import BuildaUtils
 
 public class XcodeProjectParser {
     
+    static private var sourceControlFileParsers: [SourceControlFileParser] = [
+        CheckoutFileParser(),
+        BlueprintFileParser()
+    ]
+    
     private class func firstItemMatchingTestRecursive(url: NSURL, test: (itemUrl: NSURL) -> Bool) throws -> NSURL? {
         
         let fm = NSFileManager.defaultManager()
@@ -52,38 +57,42 @@ public class XcodeProjectParser {
         return filtered
     }
     
-    private class func findCheckoutUrl(workspaceUrl: NSURL) throws -> NSURL {
+    private class func findCheckoutOrBlueprintUrl(workspaceUrl: NSURL) throws -> NSURL {
         
         if let found = try self.firstItemMatchingTestRecursive(workspaceUrl, test: { (itemUrl: NSURL) -> Bool in
             
-            return itemUrl.pathExtension == "xccheckout"
+            let pathExtension = itemUrl.pathExtension
+            return pathExtension == "xccheckout" || pathExtension == "xcscmblueprint"
         }) {
             return found
         }
-        throw Error.withInfo("No xccheckout file found")
+        throw Error.withInfo("No xccheckout or xcscmblueprint file found")
     }
     
-    private class func parseCheckoutFile(url: NSURL) throws -> NSDictionary {
-
-        if let parsed = NSDictionary(contentsOfURL: url) {
-            return parsed
-        }
-        throw Error.withInfo("Could not parse checkout file at url \(url)")
-    }
-    
-    public class func parseRepoMetadataFromProjectOrWorkspaceURL(url: NSURL) throws -> NSDictionary {
+    private class func parseCheckoutOrBlueprintFile(url: NSURL) throws -> WorkspaceMetadata {
         
-        let workspaceUrl = url
-        var checkoutUrl: NSURL
+        let pathExtension = url.pathExtension!
+        
+        let maybeParser = self.sourceControlFileParsers.filter {
+            Set($0.supportedFileExtensions()).contains(pathExtension)
+        }.first
+        guard let parser = maybeParser else {
+            throw Error.withInfo("Could not find a parser for path extension \(pathExtension)")
+        }
+        
+        let parsedWorkspace = try parser.parseFileAtUrl(url)
+        return parsedWorkspace
+    }
+    
+    public class func parseRepoMetadataFromProjectOrWorkspaceURL(url: NSURL) throws -> WorkspaceMetadata {
         
         do {
-            checkoutUrl = try self.findCheckoutUrl(workspaceUrl)
+            let checkoutUrl = try self.findCheckoutOrBlueprintUrl(url)
+            let parsed = try self.parseCheckoutOrBlueprintFile(checkoutUrl)
+            return parsed
         } catch {
-            throw Error.withInfo("Cannot find the Checkout file, please make sure to open this project in Xcode at least once (it will generate the required Checkout file). Then try again.")
+            throw Error.withInfo("Cannot find the Checkout/Blueprint file, please make sure to open this project in Xcode at least once (it will generate the required Checkout/Blueprint file) and create at least one Bot from Xcode. Then please try again. Create an issue on GitHub is this issue persists.")
         }
-        
-        let parsed = try self.parseCheckoutFile(checkoutUrl)
-        return parsed
     }
     
     public class func sharedSchemeUrlsFromProjectOrWorkspaceUrl(url: NSURL) -> [NSURL] {

--- a/Buildasaur.xcodeproj/project.pbxproj
+++ b/Buildasaur.xcodeproj/project.pbxproj
@@ -7,6 +7,8 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		3A2024AB1BBAF60A0093807F /* SourceControlFileParser.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3A2024AA1BBAF60A0093807F /* SourceControlFileParser.swift */; settings = {ASSET_TAGS = (); }; };
+		3A2024AD1BBAF64B0093807F /* WorkspaceMetadata.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3A2024AC1BBAF64B0093807F /* WorkspaceMetadata.swift */; settings = {ASSET_TAGS = (); }; };
 		3A3231B11B5AEF7900B53E3F /* Logging.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3A3231B01B5AEF7900B53E3F /* Logging.swift */; };
 		3A32CD141A3D00F800861A34 /* Comment.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3A32CD131A3D00F800861A34 /* Comment.swift */; };
 		3A32CD181A3D01E300861A34 /* Issue.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3A32CD171A3D01E300861A34 /* Issue.swift */; };
@@ -177,6 +179,8 @@
 		1F8594F1047EB3CC3762E83A /* Pods-BuildaKit.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-BuildaKit.release.xcconfig"; path = "Pods/Target Support Files/Pods-BuildaKit/Pods-BuildaKit.release.xcconfig"; sourceTree = "<group>"; };
 		2705613A9D9BA7B4398ED478 /* Pods_Buildasaur.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_Buildasaur.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		30857BA7B7416223483A4226 /* Pods-BuildaKitTests.testing.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-BuildaKitTests.testing.xcconfig"; path = "Pods/Target Support Files/Pods-BuildaKitTests/Pods-BuildaKitTests.testing.xcconfig"; sourceTree = "<group>"; };
+		3A2024AA1BBAF60A0093807F /* SourceControlFileParser.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SourceControlFileParser.swift; sourceTree = "<group>"; };
+		3A2024AC1BBAF64B0093807F /* WorkspaceMetadata.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = WorkspaceMetadata.swift; sourceTree = "<group>"; };
 		3A3231B01B5AEF7900B53E3F /* Logging.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Logging.swift; sourceTree = "<group>"; };
 		3A32CD131A3D00F800861A34 /* Comment.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Comment.swift; sourceTree = "<group>"; };
 		3A32CD171A3D01E300861A34 /* Issue.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Issue.swift; sourceTree = "<group>"; };
@@ -467,6 +471,8 @@
 				3ACBADF91B5ADE2A00204457 /* XcodeProject.swift */,
 				3ACBADFA1B5ADE2A00204457 /* XcodeProjectParser.swift */,
 				3ACBADFB1B5ADE2A00204457 /* XcodeServerSyncerUtils.swift */,
+				3A2024AA1BBAF60A0093807F /* SourceControlFileParser.swift */,
+				3A2024AC1BBAF64B0093807F /* WorkspaceMetadata.swift */,
 			);
 			path = BuildaKit;
 			sourceTree = "<group>";
@@ -1123,6 +1129,7 @@
 				3ACBAE081B5ADE2A00204457 /* SyncerBotUtils.swift in Sources */,
 				3ACBADFD1B5ADE2A00204457 /* CommonExtensions.swift in Sources */,
 				3ACBAE131B5ADE2A00204457 /* SyncPairResolver.swift in Sources */,
+				3A2024AD1BBAF64B0093807F /* WorkspaceMetadata.swift in Sources */,
 				3ACBAE0A1B5ADE2A00204457 /* SyncPair_Branch_Bot.swift in Sources */,
 				3ACBADFE1B5ADE2A00204457 /* HDGitHubXCBotSyncer.swift in Sources */,
 				3ACBAE071B5ADE2A00204457 /* SyncerBotNaming.swift in Sources */,
@@ -1140,6 +1147,7 @@
 				3ACBAE121B5ADE2A00204457 /* SyncPairPRResolver.swift in Sources */,
 				3ACBAE151B5ADE2A00204457 /* XcodeProject.swift in Sources */,
 				3ACBAE161B5ADE2A00204457 /* XcodeProjectParser.swift in Sources */,
+				3A2024AB1BBAF60A0093807F /* SourceControlFileParser.swift in Sources */,
 				3ACBAE091B5ADE2A00204457 /* SyncerGitHubUtils.swift in Sources */,
 				3ACBAE001B5ADE2A00204457 /* Persistence.swift in Sources */,
 				3ACBAE0B1B5ADE2A00204457 /* SyncPair_Branch_NoBot.swift in Sources */,

--- a/Buildasaur.xcworkspace/xcshareddata/Buildasaur.xcscmblueprint
+++ b/Buildasaur.xcworkspace/xcshareddata/Buildasaur.xcscmblueprint
@@ -4,12 +4,10 @@
 
   },
   "DVTSourceControlWorkspaceBlueprintWorkingCopyStatesKey" : {
-    "A36AEFA3F9FF1F738E92F0C497C14977DCE02B97" : 0,
     "1C5C2A17EEADA6DBF6678501245487A71FBE28BB" : 0
   },
   "DVTSourceControlWorkspaceBlueprintIdentifierKey" : "69B0DA2F-5930-4961-9871-EF4103C70CA9",
   "DVTSourceControlWorkspaceBlueprintWorkingCopyPathsKey" : {
-    "A36AEFA3F9FF1F738E92F0C497C14977DCE02B97" : "Buildasaur-XcodeServerSDK",
     "1C5C2A17EEADA6DBF6678501245487A71FBE28BB" : "Buildasaur"
   },
   "DVTSourceControlWorkspaceBlueprintNameKey" : "Buildasaur",
@@ -20,11 +18,6 @@
       "DVTSourceControlWorkspaceBlueprintRemoteRepositoryURLKey" : "github.com:czechboy0\/Buildasaur.git",
       "DVTSourceControlWorkspaceBlueprintRemoteRepositorySystemKey" : "com.apple.dt.Xcode.sourcecontrol.Git",
       "DVTSourceControlWorkspaceBlueprintRemoteRepositoryIdentifierKey" : "1C5C2A17EEADA6DBF6678501245487A71FBE28BB"
-    },
-    {
-      "DVTSourceControlWorkspaceBlueprintRemoteRepositoryURLKey" : "github.com:czechboy0\/XcodeServerSDK.git",
-      "DVTSourceControlWorkspaceBlueprintRemoteRepositorySystemKey" : "com.apple.dt.Xcode.sourcecontrol.Git",
-      "DVTSourceControlWorkspaceBlueprintRemoteRepositoryIdentifierKey" : "A36AEFA3F9FF1F738E92F0C497C14977DCE02B97"
     }
   ]
 }

--- a/Buildasaur/Base.lproj/Main.storyboard
+++ b/Buildasaur/Base.lproj/Main.storyboard
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<document type="com.apple.InterfaceBuilder3.Cocoa.Storyboard.XIB" version="3.0" toolsVersion="8121.20" systemVersion="14E46" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none" useAutolayout="YES" initialViewController="B8D-0N-5wS">
+<document type="com.apple.InterfaceBuilder3.Cocoa.Storyboard.XIB" version="3.0" toolsVersion="8191" systemVersion="14F27" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none" useAutolayout="YES" initialViewController="B8D-0N-5wS">
     <dependencies>
-        <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="8121.20"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="8191"/>
         <capability name="Aspect ratio constraints" minToolsVersion="5.1"/>
     </dependencies>
     <scenes>

--- a/Buildasaur/BuildTemplateViewController.swift
+++ b/Buildasaur/BuildTemplateViewController.swift
@@ -80,7 +80,7 @@ class BuildTemplateViewController: SetupViewController, NSComboBoxDelegate, NSTa
         
         let temp = self.buildTemplate
 
-        let projectName = self.project.projectName
+        let projectName = self.project.workspaceMetadata!.projectName
         self.buildTemplate.projectName = projectName
 
         //name

--- a/Buildasaur/StatusProjectViewController.swift
+++ b/Buildasaur/StatusProjectViewController.swift
@@ -63,7 +63,7 @@ class StatusProjectViewController: StatusViewController, NSComboBoxDelegate, Set
                 let projectName = template.projectName,
                 let project = self.project()
             {
-                return projectName == project.projectName ?? ""
+                return projectName == project.workspaceMetadata?.projectName ?? ""
             } else {
                 //if it doesn't yet have a project name associated, assume we have to show it
                 return true
@@ -91,8 +91,8 @@ class StatusProjectViewController: StatusViewController, NSComboBoxDelegate, Set
             self.sshPassphraseTextField.stringValue = project.sshPassphrase ?? ""
             
             //fill data in
-            self.projectNameLabel.stringValue = project.projectName ?? "<NO NAME>"
-            self.projectURLLabel.stringValue = project.projectURL?.absoluteString ?? "<NO URL>"
+            self.projectNameLabel.stringValue = project.workspaceMetadata?.projectName ?? "<NO NAME>"
+            self.projectURLLabel.stringValue = project.workspaceMetadata?.projectURL.absoluteString ?? "<NO URL>"
             self.projectPathLabel.stringValue = project.url.path ?? "<NO PATH>"
             
             if let githubToken = project.githubToken {
@@ -189,7 +189,7 @@ class StatusProjectViewController: StatusViewController, NSComboBoxDelegate, Set
                 buildTemplate = self.buildTemplates().filter({ $0.name == templatePulled }).first
             }
             if buildTemplate == nil {
-                buildTemplate = BuildTemplate(projectName: self.project()!.projectName!)
+                buildTemplate = BuildTemplate(projectName: self.project()!.workspaceMetadata!.projectName)
             }
             
             self.delegate.showBuildTemplateViewControllerForTemplate(buildTemplate, project: self.project()!, sender: self)

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -17,4 +17,4 @@ SPEC CHECKSUMS:
   ekgclient: 40f5d347e2ede450b3e50ac7c6bd84d96e7b84ad
   XcodeServerSDK: 177cebc86a5b78e7309bcb1a9b3fae045a4eda6a
 
-COCOAPODS: 0.38.2
+COCOAPODS: 0.39.0.beta.3


### PR DESCRIPTION
Refactored how we parse checkout files, migrated to a nice `WorkspaceMetadata` struct instead of a dictionary, added more Swift 2-style error handling. Now we also recognize the new `.xcscmblueprint` files.

Tested everything, but as always, if anything comes up, let me know.
