### PR TITLE
Fixed unrecognized schemes owned by workspace

### DIFF
--- a/BuildaKit/Project.swift
+++ b/BuildaKit/Project.swift
@@ -141,11 +141,10 @@ public class Project : JSONSerializable {
         return json
     }
     
-    public func schemeNames() -> [String] {
+    public func schemes() -> [XcodeScheme] {
         
-        let schemes = XcodeProjectParser.sharedSchemeUrlsFromProjectOrWorkspaceUrl(self.url)
-        let names = schemes.map { ($0.lastPathComponent! as NSString).stringByDeletingPathExtension }
-        return names
+        let schemes = XcodeProjectParser.sharedSchemesFromProjectOrWorkspaceUrl(self.url)
+        return schemes
     }
     
     private class func loadWorkspaceMetadata(url: NSURL) throws -> WorkspaceMetadata {

--- a/BuildaKit/XcodeScheme.swift
+++ b/BuildaKit/XcodeScheme.swift
@@ -1,0 +1,26 @@
+//
+//  XcodeScheme.swift
+//  Buildasaur
+//
+//  Created by Honza Dvorsky on 02/10/2015.
+//  Copyright © 2015 Honza Dvorsky. All rights reserved.
+//
+
+import Foundation
+
+extension NSURL {
+    
+    public var fileNameNoExtension: String? {
+        return ((self.lastPathComponent ?? "") as NSString).stringByDeletingPathExtension
+    }
+}
+
+public struct XcodeScheme {
+    
+    public var name: String {
+        return self.path.fileNameNoExtension!
+    }
+    
+    public let path: NSURL
+    public let ownerProjectOrWorkspace: NSURL
+}

--- a/Buildasaur.xcodeproj/project.pbxproj
+++ b/Buildasaur.xcodeproj/project.pbxproj
@@ -87,6 +87,7 @@
 		3ACBAE151B5ADE2A00204457 /* XcodeProject.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3ACBADF91B5ADE2A00204457 /* XcodeProject.swift */; };
 		3ACBAE161B5ADE2A00204457 /* XcodeProjectParser.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3ACBADFA1B5ADE2A00204457 /* XcodeProjectParser.swift */; };
 		3ACBAE171B5ADE2A00204457 /* XcodeServerSyncerUtils.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3ACBADFB1B5ADE2A00204457 /* XcodeServerSyncerUtils.swift */; };
+		3ACF93A41BBE80B400CD888C /* XcodeScheme.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3ACF93A31BBE80B400CD888C /* XcodeScheme.swift */; settings = {ASSET_TAGS = (); }; };
 		3AD338B01AAE31D500ECD0F2 /* BuildTemplateViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3AD338AF1AAE31D500ECD0F2 /* BuildTemplateViewController.swift */; };
 		3AF090B81B1134AA0058567F /* BranchWatchingViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3AF090B71B1134AA0058567F /* BranchWatchingViewController.swift */; };
 		3AF1B1241AAC7CA500917EF3 /* StatusSyncerViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3AF1B1231AAC7CA500917EF3 /* StatusSyncerViewController.swift */; };
@@ -262,6 +263,7 @@
 		3ACBADF91B5ADE2A00204457 /* XcodeProject.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = XcodeProject.swift; sourceTree = "<group>"; };
 		3ACBADFA1B5ADE2A00204457 /* XcodeProjectParser.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = XcodeProjectParser.swift; sourceTree = "<group>"; };
 		3ACBADFB1B5ADE2A00204457 /* XcodeServerSyncerUtils.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = XcodeServerSyncerUtils.swift; sourceTree = "<group>"; };
+		3ACF93A31BBE80B400CD888C /* XcodeScheme.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = XcodeScheme.swift; sourceTree = "<group>"; };
 		3AD338AF1AAE31D500ECD0F2 /* BuildTemplateViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = BuildTemplateViewController.swift; sourceTree = "<group>"; };
 		3AF090B71B1134AA0058567F /* BranchWatchingViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = BranchWatchingViewController.swift; sourceTree = "<group>"; };
 		3AF1B1231AAC7CA500917EF3 /* StatusSyncerViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = StatusSyncerViewController.swift; sourceTree = "<group>"; };
@@ -473,6 +475,7 @@
 				3ACBADFB1B5ADE2A00204457 /* XcodeServerSyncerUtils.swift */,
 				3A2024AA1BBAF60A0093807F /* SourceControlFileParser.swift */,
 				3A2024AC1BBAF64B0093807F /* WorkspaceMetadata.swift */,
+				3ACF93A31BBE80B400CD888C /* XcodeScheme.swift */,
 			);
 			path = BuildaKit;
 			sourceTree = "<group>";
@@ -1143,6 +1146,7 @@
 				3ACBAE061B5ADE2A00204457 /* SyncerBotManipulation.swift in Sources */,
 				3ACBAE021B5ADE2A00204457 /* SSHKeyVerification.swift in Sources */,
 				3ACBAE111B5ADE2A00204457 /* SyncPairExtensions.swift in Sources */,
+				3ACF93A41BBE80B400CD888C /* XcodeScheme.swift in Sources */,
 				3ACBADFC1B5ADE2A00204457 /* BuildTemplate.swift in Sources */,
 				3ACBAE121B5ADE2A00204457 /* SyncPairPRResolver.swift in Sources */,
 				3ACBAE151B5ADE2A00204457 /* XcodeProject.swift in Sources */,

--- a/Buildasaur/BuildTemplateViewController.swift
+++ b/Buildasaur/BuildTemplateViewController.swift
@@ -74,9 +74,9 @@ class BuildTemplateViewController: SetupViewController, NSComboBoxDelegate, NSTa
         self.testDeviceFilterComboBox.usesDataSource = true
         self.testDeviceFilterComboBox.dataSource = self
         
-        let schemes = self.project.schemeNames()
+        let schemeNames = self.project.schemes().map { $0.name }
         self.schemesComboBox.removeAllItems()
-        self.schemesComboBox.addItemsWithObjectValues(schemes)
+        self.schemesComboBox.addItemsWithObjectValues(schemeNames)
         
         let temp = self.buildTemplate
 
@@ -345,14 +345,19 @@ class BuildTemplateViewController: SetupViewController, NSComboBoxDelegate, NSTa
         //validate that the selection is valid
         if let selectedScheme = self.schemesComboBox.objectValueOfSelectedItem as? String
         {
-            let schemes = self.project.schemeNames()
-            if schemes.indexOf(selectedScheme) != nil {
+            let schemes = self.project.schemes()
+            let schemeNames = schemes.map { $0.name }
+            let index = schemeNames.indexOf(selectedScheme)
+            if let index = index {
+                
+                let scheme = schemes[index]
+                
                 //found it, good, use it
                 self.buildTemplate.scheme = selectedScheme
                 
                 //also refresh devices for testing based on the scheme type
                 do {
-                    let platformType = try XcodeDeviceParser.parseDeviceTypeFromProjectUrlAndScheme(self.project.url, scheme: selectedScheme).toPlatformType()
+                    let platformType = try XcodeDeviceParser.parseDeviceTypeFromProjectUrlAndScheme(self.project.url, scheme: scheme).toPlatformType()
                     self.buildTemplate.platformType = platformType
                     self.reloadUI()
                     self.fetchDevices({ () -> () in


### PR DESCRIPTION
Fixed a bug where we'd not be able to read schemes owned by the workspace.
Also detects schemes from projects not in the same directory as the workspace/main project (e.g. Pods)

Fixes #144.
