### PR TITLE
Deep links into Xcode from GitHub comments

### DIFF
--- a/BuildaKit/SyncPairResolver.swift
+++ b/BuildaKit/SyncPairResolver.swift
@@ -194,7 +194,13 @@ public class SyncPairResolver {
     
     class func linkToServer(hostname: String, bot: Bot, integration: Integration) -> String {
         
-        let link = "xcbot://\(hostname)/botID/\(bot.id)/integrationID/\(integration.id)"
+        //unfortunately, since github doesn't allow non-https links anywhere, we
+        //must proxy through Satellite (https://github.com/czechboy0/satellite)
+        //all it does is it redirects to the desired xcbot://... url, which in
+        //turn opens Xcode on the integration page. all good!
+        
+//        let link = "xcbot://\(hostname)/botID/\(bot.id)/integrationID/\(integration.id)"
+        let link = "https://stlt.herokuapp.com/v1/xcs_deeplink/\(hostname)/\(bot.id)/\(integration.id)"
         return link
     }
     

--- a/BuildaKit/SyncPair_Branch_Bot.swift
+++ b/BuildaKit/SyncPair_Branch_Bot.swift
@@ -42,24 +42,33 @@ public class SyncPair_Branch_Bot: SyncPair {
         let headCommit = self.branch.commit.sha
         let issue: Issue? = nil //TODO: only pull/create if we're failing
         
-        self.getIntegrations(bot, completion: { (integrations, error) -> () in
+        self.syncer.xcodeServer.getHostname { (hostname, error) -> () in
             
             if let error = error {
                 completion(error: error)
                 return
             }
             
-            let actions = self.resolver.resolveActionsForCommitAndIssueWithBotIntegrations(
-                headCommit,
-                issue: issue,
-                bot: bot,
-                integrations: integrations)
-            
-            //in case of branches, we also (optionally) want to add functionality for creating an issue if the branch starts failing and updating with comments the same way we do with PRs.
-            //also, when the build is finally successful on the branch, the issue will be automatically closed.
-            //TODO: add this functionality here and add it as another action available from a sync pair
-            
-            self.performActions(actions, completion: completion)
-        })
+            self.getIntegrations(bot, completion: { (integrations, error) -> () in
+                
+                if let error = error {
+                    completion(error: error)
+                    return
+                }
+                
+                let actions = self.resolver.resolveActionsForCommitAndIssueWithBotIntegrations(
+                    headCommit,
+                    issue: issue,
+                    bot: bot,
+                    hostname: hostname!,
+                    integrations: integrations)
+                
+                //in case of branches, we also (optionally) want to add functionality for creating an issue if the branch starts failing and updating with comments the same way we do with PRs.
+                //also, when the build is finally successful on the branch, the issue will be automatically closed.
+                //TODO: add this functionality here and add it as another action available from a sync pair
+                
+                self.performActions(actions, completion: completion)
+            })
+        }
     }
 }

--- a/BuildaKit/SyncerBotUtils.swift
+++ b/BuildaKit/SyncerBotUtils.swift
@@ -26,11 +26,17 @@ extension HDGitHubXCBotSyncer {
         }
     }
     
-    class func baseCommentLinesFromIntegration(integration: Integration) -> [String] {
+    class func baseCommentLinesFromIntegration(integration: Integration, link: String?) -> [String] {
         
         var lines = [String]()
         
-        lines.append("Result of Integration **\(integration.number)**")
+        var integrationText = "Integration \(integration.number)"
+        if let link = link {
+            //linkify
+            integrationText = "[\(integrationText)](\(link))"
+        }
+        
+        lines.append("Result of \(integrationText)")
         lines.append("---")
         
         if let duration = self.formattedDurationOfIntegration(integration) {

--- a/BuildaKit/SyncerGitHubUtils.swift
+++ b/BuildaKit/SyncerGitHubUtils.swift
@@ -14,11 +14,9 @@ extension HDGitHubXCBotSyncer {
     
     class func createStatusFromState(state: Status.State, description: String?, targetUrl: String?) -> Status {
         
-        //TODO: add useful targetUrl and potentially have multiple contexts to show multiple stats on the PR
+        //TODO: potentially have multiple contexts to show multiple stats on the PR
         let context = "Buildasaur"
-        
-        //targetURL must be https :( use satellite to forward xcbot:// deep links?
-        return Status(state: state, description: description, targetUrl: nil, context: context)
+        return Status(state: state, description: description, targetUrl: targetUrl, context: context)
     }
     
     func updateCommitStatusIfNecessary(

--- a/BuildaKit/SyncerGitHubUtils.swift
+++ b/BuildaKit/SyncerGitHubUtils.swift
@@ -12,10 +12,12 @@ import BuildaUtils
 
 extension HDGitHubXCBotSyncer {
     
-    class func createStatusFromState(state: Status.State, description: String?) -> Status {
+    class func createStatusFromState(state: Status.State, description: String?, targetUrl: String?) -> Status {
         
         //TODO: add useful targetUrl and potentially have multiple contexts to show multiple stats on the PR
         let context = "Buildasaur"
+        
+        //targetURL must be https :( use satellite to forward xcbot:// deep links?
         return Status(state: state, description: description, targetUrl: nil, context: context)
     }
     

--- a/BuildaKitTests/SyncPair_PR_Bot_Tests.swift
+++ b/BuildaKitTests/SyncPair_PR_Bot_Tests.swift
@@ -41,7 +41,7 @@ class SyncPair_PR_Bot_Tests: XCTestCase {
         let (pr, bot, commit) = self.mockedPRAndBotAndCommit()
         let integrations = [Integration]()
         
-        let actions = SyncPairPRResolver().resolveActionsForCommitAndIssueWithBotIntegrations(commit, issue: pr, bot: bot, integrations: integrations)
+        let actions = SyncPairPRResolver().resolveActionsForCommitAndIssueWithBotIntegrations(commit, issue: pr, bot: bot, hostname: "localhost", integrations: integrations)
         XCTAssertEqual(actions.integrationsToCancel?.count ?? 0, 0)
         XCTBAssertNil(actions.githubStatusToSet)
         XCTAssertNotNil(actions.startNewIntegrationBot)
@@ -54,7 +54,7 @@ class SyncPair_PR_Bot_Tests: XCTestCase {
             MockIntegration(number: 1, step: Integration.Step.Pending)
         ]
         
-        let actions = SyncPairPRResolver().resolveActionsForCommitAndIssueWithBotIntegrations(commit, issue: pr, bot: bot, integrations: integrations)
+        let actions = SyncPairPRResolver().resolveActionsForCommitAndIssueWithBotIntegrations(commit, issue: pr, bot: bot, hostname: "localhost", integrations: integrations)
         XCTAssertEqual(actions.integrationsToCancel?.count ?? 0, 0)
         XCTAssertNil(actions.startNewIntegrationBot)
         XCTBAssertNotNil(actions.githubStatusToSet)
@@ -70,7 +70,7 @@ class SyncPair_PR_Bot_Tests: XCTestCase {
             MockIntegration(number: 3, step: Integration.Step.Pending)
         ]
         
-        let actions = SyncPairPRResolver().resolveActionsForCommitAndIssueWithBotIntegrations(commit, issue: pr, bot: bot, integrations: integrations)
+        let actions = SyncPairPRResolver().resolveActionsForCommitAndIssueWithBotIntegrations(commit, issue: pr, bot: bot, hostname: "localhost", integrations: integrations)
         
         //should cancel all except for the last one
         let toCancel = Set(actions.integrationsToCancel!)
@@ -89,7 +89,7 @@ class SyncPair_PR_Bot_Tests: XCTestCase {
             MockIntegration(number: 1, step: Integration.Step.Building),
         ]
         
-        let actions = SyncPairPRResolver().resolveActionsForCommitAndIssueWithBotIntegrations(commit, issue: pr, bot: bot, integrations: integrations)
+        let actions = SyncPairPRResolver().resolveActionsForCommitAndIssueWithBotIntegrations(commit, issue: pr, bot: bot, hostname: "localhost", integrations: integrations)
         
         XCTAssertEqual(actions.integrationsToCancel!.count, 0)
         XCTAssertNil(actions.startNewIntegrationBot)
@@ -104,7 +104,7 @@ class SyncPair_PR_Bot_Tests: XCTestCase {
             MockIntegration(number: 1, step: Integration.Step.Completed, sha: "head_sha", result: Integration.Result.TestFailures)
         ]
         
-        let actions = SyncPairPRResolver().resolveActionsForCommitAndIssueWithBotIntegrations(commit, issue: pr, bot: bot, integrations: integrations)
+        let actions = SyncPairPRResolver().resolveActionsForCommitAndIssueWithBotIntegrations(commit, issue: pr, bot: bot, hostname: "localhost", integrations: integrations)
         
         XCTAssertEqual(actions.integrationsToCancel!.count, 0)
         XCTAssertNil(actions.startNewIntegrationBot)
@@ -119,7 +119,7 @@ class SyncPair_PR_Bot_Tests: XCTestCase {
             MockIntegration(number: 1, step: Integration.Step.Completed, sha: "head_sha", result: Integration.Result.Succeeded)
         ]
         
-        let actions = SyncPairPRResolver().resolveActionsForCommitAndIssueWithBotIntegrations(commit, issue: pr, bot: bot, integrations: integrations)
+        let actions = SyncPairPRResolver().resolveActionsForCommitAndIssueWithBotIntegrations(commit, issue: pr, bot: bot, hostname: "localhost", integrations: integrations)
         
         XCTAssertEqual(actions.integrationsToCancel!.count, 0)
         XCTAssertNil(actions.startNewIntegrationBot)
@@ -135,7 +135,7 @@ class SyncPair_PR_Bot_Tests: XCTestCase {
             MockIntegration(number: 2, step: Integration.Step.Pending, sha: "head_sha")
         ]
         
-        let actions = SyncPairPRResolver().resolveActionsForCommitAndIssueWithBotIntegrations(commit, issue: pr, bot: bot, integrations: integrations)
+        let actions = SyncPairPRResolver().resolveActionsForCommitAndIssueWithBotIntegrations(commit, issue: pr, bot: bot, hostname: "localhost", integrations: integrations)
         
         XCTAssertEqual(actions.integrationsToCancel!.count, 1)
         XCTAssertNil(actions.startNewIntegrationBot)
@@ -150,7 +150,7 @@ class SyncPair_PR_Bot_Tests: XCTestCase {
             MockIntegration(number: 1, step: Integration.Step.Building, sha: "head_sha_old"),
         ]
         
-        let actions = SyncPairPRResolver().resolveActionsForCommitAndIssueWithBotIntegrations(commit, issue: pr, bot: bot, integrations: integrations)
+        let actions = SyncPairPRResolver().resolveActionsForCommitAndIssueWithBotIntegrations(commit, issue: pr, bot: bot, hostname: "localhost", integrations: integrations)
         
         XCTAssertEqual(actions.integrationsToCancel!.count, 1)
         XCTAssertNotNil(actions.startNewIntegrationBot)


### PR DESCRIPTION
Fixes #160.

However, the solution wasn't straightforward. The deep links into Xcode are in a format of `xcbot://mycomputer.local/....`, which has a scheme of `xcbot`, which isn't on GitHub's whitelist - so they were getting blocked by GitHub.

However, I'm already running a tiny server called Satellite, which is used for Buildasaur build badges. So I reused it to proxy to the required urls.

So the way it works now is that the links here on GitHub point to Satellite - and when you click on one, Satellite immediately redirects you to the right `xcbot` link. 

It's almost not noticable, so I just thought I'd let people know. But yeah - deep links for everyone!

Currently, they show up in two places:
- the build status icons are now clickable
- the build status comments posted by Buildasaur now have the "Integration X" part hyperlinked

Let me know if this works for you.
