### PR TITLE
Handling of missing Xcode project/workspaces

### DIFF
--- a/BuildaKit/SyncerProducerFactory.swift
+++ b/BuildaKit/SyncerProducerFactory.swift
@@ -80,7 +80,7 @@ class SyncerProducerFactory {
         
         let projects = configs.map { configsArray in
             return configsArray.map { factory.createProject($0) }
-        }
+        }.map { $0.filter { $0 != nil } }.map { $0.map { $0! } }
         return projects
     }
     

--- a/Buildasaur/EmptyProjectViewController.swift
+++ b/Buildasaur/EmptyProjectViewController.swift
@@ -109,6 +109,7 @@ class EmptyProjectViewController: EditableViewController {
         let configsProducer = self.storageManager.projectConfigs.producer
         let allConfigsProducer = configsProducer
             .map { Array($0.values) }
+            .map { configs in configs.filter { (try? Project(config: $0)) != nil } }
             .map { configs in configs.sort { $0.name < $1.name } }
         allConfigsProducer.startWithNext { [weak self] newConfigs in
             guard let sself = self else { return }
@@ -138,8 +139,13 @@ class EmptyProjectViewController: EditableViewController {
                 return config
             } catch {
                 //local source is malformed, something terrible must have happened, inform the user this can't be used (log should tell why exactly)
-                UIUtils.showAlertWithText("Couldn't add Xcode project at path \(url.absoluteString), error: \((error as NSError).localizedDescription).", style: NSAlertStyle.CriticalAlertStyle, completion: { (resp) -> () in
-                    //
+                let buttons = ["See workaround", "OK"]
+
+                UIUtils.showAlertWithButtons("Couldn't add Xcode project at path \(url.absoluteString), error: \((error as NSError).localizedDescription).", buttons: buttons, style: NSAlertStyle.CriticalAlertStyle, completion: { (tappedButton) -> () in
+                    
+                    if tappedButton == "See workaround" {
+                        openLink("https://github.com/czechboy0/Buildasaur/issues/165#issuecomment-148220340")
+                    }
                 })
             }
         } else {

--- a/Buildasaur/UIUtils.swift
+++ b/Buildasaur/UIUtils.swift
@@ -33,9 +33,9 @@ public class UIUtils {
         self.showAlertAskingConfirmation(text, dangerButton: "Remove", completion: completion)
     }
     
-    public class func showAlertWithButtons(text: String, buttons: [String], completion: (tappedButton: String) -> ()) {
+    public class func showAlertWithButtons(text: String, buttons: [String], style: NSAlertStyle? = nil, completion: (tappedButton: String) -> ()) {
         
-        let alert = self.createAlert(text, style: nil)
+        let alert = self.createAlert(text, style: style)
         
         buttons.forEach { alert.addButtonWithTitle($0) }
         


### PR DESCRIPTION
- we don't crash anymore when an xcode project we're pointing to is removed
- we show "See workaround" when people hit the issue with missing blueprint/checkout file
