### PR TITLE
Parsing metadata information directly from git repo (in the absence of checkout files)

### DIFF
--- a/BuildaKit/BlueprintFileParser.swift
+++ b/BuildaKit/BlueprintFileParser.swift
@@ -1,0 +1,54 @@
+//
+//  BlueprintFileParser.swift
+//  Buildasaur
+//
+//  Created by Honza Dvorsky on 10/21/15.
+//  Copyright © 2015 Honza Dvorsky. All rights reserved.
+//
+
+import Foundation
+import BuildaUtils
+
+class BlueprintFileParser: SourceControlFileParser {
+    
+    func supportedFileExtensions() -> [String] {
+        return ["xcscmblueprint"]
+    }
+    
+    func parseFileAtUrl(url: NSURL) throws -> WorkspaceMetadata {
+        
+        //JSON -> NSDictionary
+        let data = try NSData(contentsOfURL: url, options: NSDataReadingOptions())
+        let jsonObject = try NSJSONSerialization.JSONObjectWithData(data, options: NSJSONReadingOptions())
+        guard let dictionary = jsonObject as? NSDictionary else { throw Error.withInfo("Failed to parse \(url)") }
+        
+        //parse our required keys
+        let projectName = dictionary.optionalStringForKey("DVTSourceControlWorkspaceBlueprintNameKey")
+        let projectPath = dictionary.optionalStringForKey("DVTSourceControlWorkspaceBlueprintRelativePathToProjectKey")
+        let projectWCCIdentifier = dictionary.optionalStringForKey("DVTSourceControlWorkspaceBlueprintPrimaryRemoteRepositoryKey")
+        
+        var primaryRemoteRepositoryDictionary: NSDictionary?
+        if let wccId = projectWCCIdentifier {
+            if let wcConfigs = dictionary["DVTSourceControlWorkspaceBlueprintRemoteRepositoriesKey"] as? [NSDictionary] {
+                primaryRemoteRepositoryDictionary = wcConfigs.filter({
+                    if let loopWccId = $0.optionalStringForKey("DVTSourceControlWorkspaceBlueprintRemoteRepositoryIdentifierKey") {
+                        return loopWccId == wccId
+                    }
+                    return false
+                }).first
+            }
+        }
+        
+        let projectURLString = primaryRemoteRepositoryDictionary?.optionalStringForKey("DVTSourceControlWorkspaceBlueprintRemoteRepositoryURLKey")
+        
+        var projectWCCName: String?
+        if
+            let copyPaths = dictionary["DVTSourceControlWorkspaceBlueprintWorkingCopyPathsKey"] as? [String: String],
+            let primaryRemoteRepoId = projectWCCIdentifier
+        {
+            projectWCCName = copyPaths[primaryRemoteRepoId]
+        }
+        
+        return try WorkspaceMetadata(projectName: projectName, projectPath: projectPath, projectWCCIdentifier: projectWCCIdentifier, projectWCCName: projectWCCName, projectURLString: projectURLString)
+    }
+}

--- a/BuildaKit/CheckoutFileParser.swift
+++ b/BuildaKit/CheckoutFileParser.swift
@@ -1,0 +1,47 @@
+//
+//  CheckoutFileParser.swift
+//  Buildasaur
+//
+//  Created by Honza Dvorsky on 10/21/15.
+//  Copyright © 2015 Honza Dvorsky. All rights reserved.
+//
+
+import Foundation
+import BuildaUtils
+
+class CheckoutFileParser: SourceControlFileParser {
+    
+    func supportedFileExtensions() -> [String] {
+        return ["xccheckout"]
+    }
+    
+    func parseFileAtUrl(url: NSURL) throws -> WorkspaceMetadata {
+        
+        //plist -> NSDictionary
+        guard let dictionary = NSDictionary(contentsOfURL: url) else { throw Error.withInfo("Failed to parse \(url)") }
+        
+        //parse our required keys
+        let projectName = dictionary.optionalStringForKey("IDESourceControlProjectName")
+        let projectPath = dictionary.optionalStringForKey("IDESourceControlProjectPath")
+        let projectWCCIdentifier = dictionary.optionalStringForKey("IDESourceControlProjectWCCIdentifier")
+        let projectWCCName = { () -> String? in
+            if let wccId = projectWCCIdentifier {
+                if let wcConfigs = dictionary["IDESourceControlProjectWCConfigurations"] as? [NSDictionary] {
+                    if let foundConfig = wcConfigs.filter({
+                        if let loopWccId = $0.optionalStringForKey("IDESourceControlWCCIdentifierKey") {
+                            return loopWccId == wccId
+                        }
+                        return false
+                    }).first {
+                        //so much effort for this little key...
+                        return foundConfig.optionalStringForKey("IDESourceControlWCCName")
+                    }
+                }
+            }
+            return nil
+            }()
+        let projectURLString = { dictionary.optionalStringForKey("IDESourceControlProjectURL") }()
+        
+        return try WorkspaceMetadata(projectName: projectName, projectPath: projectPath, projectWCCIdentifier: projectWCCIdentifier, projectWCCName: projectWCCName, projectURLString: projectURLString)
+    }
+}

--- a/BuildaKit/GitRepoMetadataParser.swift
+++ b/BuildaKit/GitRepoMetadataParser.swift
@@ -1,0 +1,138 @@
+//
+//  GitRepoMetadataParser.swift
+//  Buildasaur
+//
+//  Created by Honza Dvorsky on 10/21/15.
+//  Copyright © 2015 Honza Dvorsky. All rights reserved.
+//
+
+import Foundation
+import BuildaUtils
+import CryptoSwift
+
+class GitRepoMetadataParser: SourceControlFileParser {
+    
+    func supportedFileExtensions() -> [String] {
+        return [] //takes anything
+    }
+    
+    private typealias ScriptRun = (String) throws -> String
+    
+    private func parseOrigin(run: ScriptRun) throws -> String {
+        
+        //find the first origin ending with "(fetch)"
+        let remotes = try run("git remote -v")
+        let fetchRemote = remotes.split("\n").filter { $0.hasSuffix("(fetch)") }.first
+        guard let remoteLine = fetchRemote else {
+            throw Error.withInfo("No fetch remote found in \(remotes)")
+        }
+        
+        //parse the fetch remote, which is
+        //e.g. "origin\tgit@github.com:czechboy0/BuildaUtils.git (fetch)"
+        let comps = remoteLine
+            .componentsSeparatedByCharactersInSet(NSCharacterSet(charactersInString: "\t "))
+            .filter { !$0.isEmpty }
+        
+        //we need at least 2 comps, take the second
+        guard comps.count >= 2 else {
+            throw Error.withInfo("Cannot parse origin url from components \(comps)")
+        }
+        
+        let remote = comps[1]
+        
+        //we got it!
+        return remote
+    }
+    
+    private func parseProjectName(url: NSURL) throws -> String {
+        
+        //that's the name of the passed-in project/workspace (most of the times)
+        let projectName = ((url.lastPathComponent ?? "") as NSString).stringByDeletingPathExtension
+        
+        guard !projectName.isEmpty else {
+            throw Error.withInfo("Failed to parse project name from url \(url)")
+        }
+        return projectName
+    }
+    
+    private func parseProjectPath(url: NSURL, run: ScriptRun) throws -> String {
+        
+        //relative path from the root of the git repo of the passed-in project
+        //or workspace file
+        let absolutePath = url.path!
+        let relativePath = "git ls-tree --full-name --name-only HEAD \"\(absolutePath)\""
+        let outPath = try run(relativePath)
+        let trimmed = outPath.trim()
+        guard !trimmed.isEmpty else {
+            throw Error.withInfo("Failed to detect relative path of project \(url), output: \(outPath)")
+        }
+        return trimmed
+    }
+    
+    private func parseProjectWCCName(url: NSURL, projectPath: String) throws -> String {
+        
+        //this is the folder name containing the git repo
+        //it's the folder name before the project path
+        //e.g. if project path is b/c/hello.xcodeproj, and the whole path
+        //to the project is /Users/me/a/b/c/hello.xcodeproj, the project wcc name
+        //would be "a"
+        
+        var projectPathComponents = projectPath.split("/")
+        var pathComponents = url.pathComponents ?? []
+        
+        //delete from the end from both lists when components equal
+        while projectPathComponents.count > 0 {
+            if pathComponents.last == projectPathComponents.last {
+                pathComponents.removeLast()
+                projectPathComponents.removeLast()
+            } else {
+                throw Error.withInfo("Logic error in parsing project WCC name, url: \(url), projectPath: \(projectPath)")
+            }
+        }
+        
+        let containingFolder = pathComponents.last! + "/"
+        return containingFolder
+    }
+    
+    private func parseProjectWCCIdentifier(projectUrl: String) throws -> String {
+        
+        //something reproducible, but i can't figure out how Xcode generates this.
+        //also - it doesn't matter, AFA it's unique
+        let hashed = projectUrl.sha1().uppercaseString
+        return hashed
+    }
+    
+    func parseFileAtUrl(url: NSURL) throws -> WorkspaceMetadata {
+        
+        let run = { (script: String) throws -> String in
+            
+            let cd = "cd \"\(url.path!)\""
+            let all = [cd, script].joinWithSeparator("\n")
+            let response = Script.runTemporaryScript(all)
+            if response.terminationStatus != 0 {
+                throw Error.withInfo("Parsing git repo metadata failed, executing \"\(all)\", status: \(response.terminationStatus), output: \(response.standardOutput), error: \(response.standardError)")
+            }
+            return response.standardOutput
+        }
+        
+        let origin = try self.parseOrigin(run)
+        let projectName = try self.parseProjectName(url)
+        let projectPath = try self.parseProjectPath(url, run: run)
+        let projectWCCName = try self.parseProjectWCCName(url, projectPath: projectPath)
+        let projectWCCIdentifier = try self.parseProjectWCCIdentifier(origin)
+        
+        return try WorkspaceMetadata(projectName: projectName, projectPath: projectPath, projectWCCIdentifier: projectWCCIdentifier, projectWCCName: projectWCCName, projectURLString: origin)
+    }
+}
+
+extension String {
+    
+    func split(separator: String) -> [String] {
+        return self.componentsSeparatedByString(separator)
+    }
+    
+    func trim() -> String {
+        return self.stringByTrimmingCharactersInSet(NSCharacterSet.whitespaceAndNewlineCharacterSet())
+    }
+}
+

--- a/BuildaKit/SourceControlFileParser.swift
+++ b/BuildaKit/SourceControlFileParser.swift
@@ -7,92 +7,10 @@
 //
 
 import Foundation
-import BuildaUtils
 
 protocol SourceControlFileParser {
 
     func supportedFileExtensions() -> [String]
     func parseFileAtUrl(url: NSURL) throws -> WorkspaceMetadata
-}
-
-class CheckoutFileParser: SourceControlFileParser {
-    
-    func supportedFileExtensions() -> [String] {
-        return ["xccheckout"]
-    }
-    
-    func parseFileAtUrl(url: NSURL) throws -> WorkspaceMetadata {
-        
-        //plist -> NSDictionary
-        guard let dictionary = NSDictionary(contentsOfURL: url) else { throw Error.withInfo("Failed to parse \(url)") }
-        
-        //parse our required keys
-        let projectName = dictionary.optionalStringForKey("IDESourceControlProjectName")
-        let projectPath = dictionary.optionalStringForKey("IDESourceControlProjectPath")
-        let projectWCCIdentifier = dictionary.optionalStringForKey("IDESourceControlProjectWCCIdentifier")
-        let projectWCCName = { () -> String? in
-            if let wccId = projectWCCIdentifier {
-                if let wcConfigs = dictionary["IDESourceControlProjectWCConfigurations"] as? [NSDictionary] {
-                    if let foundConfig = wcConfigs.filter({
-                        if let loopWccId = $0.optionalStringForKey("IDESourceControlWCCIdentifierKey") {
-                            return loopWccId == wccId
-                        }
-                        return false
-                    }).first {
-                        //so much effort for this little key...
-                        return foundConfig.optionalStringForKey("IDESourceControlWCCName")
-                    }
-                }
-            }
-            return nil
-            }()
-        let projectURLString = { dictionary.optionalStringForKey("IDESourceControlProjectURL") }()
-        
-        return try WorkspaceMetadata(projectName: projectName, projectPath: projectPath, projectWCCIdentifier: projectWCCIdentifier, projectWCCName: projectWCCName, projectURLString: projectURLString)
-    }
-}
-
-class BlueprintFileParser: SourceControlFileParser {
-    
-    func supportedFileExtensions() -> [String] {
-        return ["xcscmblueprint"]
-    }
-    
-    func parseFileAtUrl(url: NSURL) throws -> WorkspaceMetadata {
-
-        //JSON -> NSDictionary
-        let data = try NSData(contentsOfURL: url, options: NSDataReadingOptions())
-        let jsonObject = try NSJSONSerialization.JSONObjectWithData(data, options: NSJSONReadingOptions())
-        guard let dictionary = jsonObject as? NSDictionary else { throw Error.withInfo("Failed to parse \(url)") }
-
-        //parse our required keys
-        let projectName = dictionary.optionalStringForKey("DVTSourceControlWorkspaceBlueprintNameKey")
-        let projectPath = dictionary.optionalStringForKey("DVTSourceControlWorkspaceBlueprintRelativePathToProjectKey")
-        let projectWCCIdentifier = dictionary.optionalStringForKey("DVTSourceControlWorkspaceBlueprintPrimaryRemoteRepositoryKey")
-        
-        var primaryRemoteRepositoryDictionary: NSDictionary?
-        if let wccId = projectWCCIdentifier {
-            if let wcConfigs = dictionary["DVTSourceControlWorkspaceBlueprintRemoteRepositoriesKey"] as? [NSDictionary] {
-                primaryRemoteRepositoryDictionary = wcConfigs.filter({
-                    if let loopWccId = $0.optionalStringForKey("DVTSourceControlWorkspaceBlueprintRemoteRepositoryIdentifierKey") {
-                        return loopWccId == wccId
-                    }
-                    return false
-                }).first
-            }
-        }
-        
-        let projectURLString = primaryRemoteRepositoryDictionary?.optionalStringForKey("DVTSourceControlWorkspaceBlueprintRemoteRepositoryURLKey")
-        
-        var projectWCCName: String?
-        if
-            let copyPaths = dictionary["DVTSourceControlWorkspaceBlueprintWorkingCopyPathsKey"] as? [String: String],
-            let primaryRemoteRepoId = projectWCCIdentifier
-        {
-            projectWCCName = copyPaths[primaryRemoteRepoId]
-        }
-        
-        return try WorkspaceMetadata(projectName: projectName, projectPath: projectPath, projectWCCIdentifier: projectWCCIdentifier, projectWCCName: projectWCCName, projectURLString: projectURLString)
-    }
 }
 

--- a/BuildaKit/XcodeProjectParser.swift
+++ b/BuildaKit/XcodeProjectParser.swift
@@ -13,7 +13,7 @@ public class XcodeProjectParser {
     
     static private var sourceControlFileParsers: [SourceControlFileParser] = [
         CheckoutFileParser(),
-        BlueprintFileParser()
+        BlueprintFileParser(),
     ]
     
     private class func firstItemMatchingTestRecursive(url: NSURL, test: (itemUrl: NSURL) -> Bool) throws -> NSURL? {
@@ -91,7 +91,16 @@ public class XcodeProjectParser {
             let parsed = try self.parseCheckoutOrBlueprintFile(checkoutUrl)
             return parsed
         } catch {
-            throw Error.withInfo("Cannot find the Checkout/Blueprint file, please make sure to open this project in Xcode at least once (it will generate the required Checkout/Blueprint file) and create at least one Bot from Xcode. Then please try again. Create an issue on GitHub is this issue persists. (Error \((error as NSError).localizedDescription))")
+            
+            //failed to find a checkout/blueprint file, attempt to parse from repo manually
+            let parser = GitRepoMetadataParser()
+            
+            do {
+                return try parser.parseFileAtUrl(url)
+            } catch {
+                //no we're definitely unable to parse workspace metadata
+                throw Error.withInfo("Cannot find the Checkout/Blueprint file and failed to parse repository metadata directly. Please create an issue on GitHub with anonymized information about your repository. (Error \((error as NSError).localizedDescription))")
+            }
         }
     }
     

--- a/Buildasaur.xcodeproj/project.pbxproj
+++ b/Buildasaur.xcodeproj/project.pbxproj
@@ -21,6 +21,9 @@
 		3A32CD1E1A3D2ADD00861A34 /* GitHubServerExtensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3A32CD1D1A3D2ADD00861A34 /* GitHubServerExtensions.swift */; };
 		3A395B551BCF007000BB6947 /* LoginItem.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3A395B541BCF007000BB6947 /* LoginItem.swift */; settings = {ASSET_TAGS = (); }; };
 		3A3BDC1F1AF6D34900D2CD99 /* GitHubRateLimit.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3A3BDC1E1AF6D34900D2CD99 /* GitHubRateLimit.swift */; };
+		3A3BF8C71BD7C1680050A0B7 /* CheckoutFileParser.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3A3BF8C61BD7C1680050A0B7 /* CheckoutFileParser.swift */; settings = {ASSET_TAGS = (); }; };
+		3A3BF8C91BD7C1920050A0B7 /* BlueprintFileParser.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3A3BF8C81BD7C1920050A0B7 /* BlueprintFileParser.swift */; settings = {ASSET_TAGS = (); }; };
+		3A3BF8CB1BD7C1E50050A0B7 /* GitRepoMetadataParser.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3A3BF8CA1BD7C1E50050A0B7 /* GitRepoMetadataParser.swift */; settings = {ASSET_TAGS = (); }; };
 		3A4C159F1BBB2DD0007FA970 /* SourceControlFileParser.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3A4C159D1BBB2DD0007FA970 /* SourceControlFileParser.swift */; settings = {ASSET_TAGS = (); }; };
 		3A4C15A01BBB2DD0007FA970 /* WorkspaceMetadata.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3A4C159E1BBB2DD0007FA970 /* WorkspaceMetadata.swift */; settings = {ASSET_TAGS = (); }; };
 		3A56556E1BC059E7008BD142 /* SyncerProducerFactory.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3A56556D1BC059E7008BD142 /* SyncerProducerFactory.swift */; settings = {ASSET_TAGS = (); }; };
@@ -232,6 +235,9 @@
 		3A38CF951A3CE94C00F41AFA /* Status.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = Status.swift; path = BuildaGitServer/Status.swift; sourceTree = SOURCE_ROOT; };
 		3A395B541BCF007000BB6947 /* LoginItem.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = LoginItem.swift; sourceTree = "<group>"; };
 		3A3BDC1E1AF6D34900D2CD99 /* GitHubRateLimit.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = GitHubRateLimit.swift; sourceTree = "<group>"; };
+		3A3BF8C61BD7C1680050A0B7 /* CheckoutFileParser.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = CheckoutFileParser.swift; sourceTree = "<group>"; };
+		3A3BF8C81BD7C1920050A0B7 /* BlueprintFileParser.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = BlueprintFileParser.swift; sourceTree = "<group>"; };
+		3A3BF8CA1BD7C1E50050A0B7 /* GitRepoMetadataParser.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = GitRepoMetadataParser.swift; sourceTree = "<group>"; };
 		3A4770A51A746BC00016E170 /* Buildasaur.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.xml; path = Buildasaur.entitlements; sourceTree = "<group>"; };
 		3A4C159D1BBB2DD0007FA970 /* SourceControlFileParser.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SourceControlFileParser.swift; sourceTree = "<group>"; };
 		3A4C159E1BBB2DD0007FA970 /* WorkspaceMetadata.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = WorkspaceMetadata.swift; sourceTree = "<group>"; };
@@ -758,6 +764,9 @@
 			isa = PBXGroup;
 			children = (
 				3A4C159D1BBB2DD0007FA970 /* SourceControlFileParser.swift */,
+				3A3BF8C61BD7C1680050A0B7 /* CheckoutFileParser.swift */,
+				3A3BF8C81BD7C1920050A0B7 /* BlueprintFileParser.swift */,
+				3A3BF8CA1BD7C1E50050A0B7 /* GitRepoMetadataParser.swift */,
 				3A4C159E1BBB2DD0007FA970 /* WorkspaceMetadata.swift */,
 				3ACBADF81B5ADE2A00204457 /* XcodeDeviceParser.swift */,
 				3ACBADF91B5ADE2A00204457 /* XcodeProject.swift */,
@@ -1422,6 +1431,7 @@
 				3A28AF531BC984850011756E /* ConfigTriplet.swift in Sources */,
 				3ACBADFD1B5ADE2A00204457 /* CommonExtensions.swift in Sources */,
 				3ACBAE131B5ADE2A00204457 /* SyncPairResolver.swift in Sources */,
+				3A3BF8C91BD7C1920050A0B7 /* BlueprintFileParser.swift in Sources */,
 				3A4C15A01BBB2DD0007FA970 /* WorkspaceMetadata.swift in Sources */,
 				3ACBAE0A1B5ADE2A00204457 /* SyncPair_Branch_Bot.swift in Sources */,
 				3ACBADFE1B5ADE2A00204457 /* HDGitHubXCBotSyncer.swift in Sources */,
@@ -1433,6 +1443,7 @@
 				3A3231B11B5AEF7900B53E3F /* Logging.swift in Sources */,
 				3ACBAE051B5ADE2A00204457 /* Syncer.swift in Sources */,
 				3A9C95A51BBDAE9F00D37135 /* SyncerLogic.swift in Sources */,
+				3A3BF8CB1BD7C1E50050A0B7 /* GitRepoMetadataParser.swift in Sources */,
 				3ACBAE041B5ADE2A00204457 /* StorageUtils.swift in Sources */,
 				3A0FF5A21BBFE8BA00FB8051 /* SyncerConfig.swift in Sources */,
 				3A56556E1BC059E7008BD142 /* SyncerProducerFactory.swift in Sources */,
@@ -1444,6 +1455,7 @@
 				3ACBADFC1B5ADE2A00204457 /* BuildTemplate.swift in Sources */,
 				3ACBAE121B5ADE2A00204457 /* SyncPairPRResolver.swift in Sources */,
 				3ACBAE151B5ADE2A00204457 /* XcodeProject.swift in Sources */,
+				3A3BF8C71BD7C1680050A0B7 /* CheckoutFileParser.swift in Sources */,
 				3ACBAE161B5ADE2A00204457 /* XcodeProjectParser.swift in Sources */,
 				3AE4F6CE1BBC88450006CA1C /* RACUtils.swift in Sources */,
 				3A4C159F1BBB2DD0007FA970 /* SourceControlFileParser.swift in Sources */,

--- a/Podfile
+++ b/Podfile
@@ -19,6 +19,7 @@ def buildasaur_app_pods
     also_xcode_pods
     rac
     pod 'Ji', '1.1.2'
+    pod 'CryptoSwift'
 end
 
 def test_pods

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -1,6 +1,7 @@
 PODS:
   - Alamofire (2.0.0-beta.3)
   - BuildaUtils (0.2.2)
+  - CryptoSwift (0.1.1)
   - ekgclient (0.3.0):
     - Alamofire (= 2.0.0-beta.3)
   - Ji (1.1.2):
@@ -26,6 +27,7 @@ PODS:
 
 DEPENDENCIES:
   - BuildaUtils (~> 0.2.2)
+  - CryptoSwift
   - ekgclient (~> 0.3.0)
   - Ji (= 1.1.2)
   - Nimble (~> 2.0.0-rc.3)
@@ -35,6 +37,7 @@ DEPENDENCIES:
 SPEC CHECKSUMS:
   Alamofire: 39dddb7d3725d1771b1d2f7099c8bd45bd83ffbb
   BuildaUtils: 64b8f7ee64d7d10bfb858d041f7cba41c2a5434f
+  CryptoSwift: c11640d3d66107efc8333e4131a5173f072b1d61
   ekgclient: 40f5d347e2ede450b3e50ac7c6bd84d96e7b84ad
   Ji: 477ec17f9abe9d7f016d714f7b5da8c3c67a2e15
   Nimble: 472e75466819eb8c06299233e87c694a9b51328a


### PR DESCRIPTION
- added as the last resort when neither `xccheckout` nor `xcscmblueprint` file is found
- parses information directly from the repo
- _caveat_: bots created from this metadata cannot be edited without going corrupt (because I can't reproduce the same workspace hash identifier as Xcode and when you try to edit it, it gets corrupt on saving)

Fixes #186.
