### PR TITLE
Change the device sort to incorporate name and OS version.

### DIFF
--- a/Buildasaur/BuildTemplateViewController.swift
+++ b/Buildasaur/BuildTemplateViewController.swift
@@ -466,16 +466,25 @@ class BuildTemplateViewController: ConfigEditViewController, NSTableViewDataSour
             return (equal: false, shouldGoBefore: !a.simulator)
         }
         
-        let sortConnected = {
+        let sortByName = {
             (a: Device, b: Device) -> (equal: Bool, shouldGoBefore: Bool) in
             
-            if a.connected == b.connected {
+            if a.name == b.name {
                 return (equal: true, shouldGoBefore: false)
             }
-            return (equal: false, shouldGoBefore: a.connected)
+            return (equal: false, shouldGoBefore: a.name < b.name)
+        }
+
+        let sortByOSVersion = {
+            (a: Device, b: Device) -> (equal: Bool, shouldGoBefore: Bool) in
+            
+            if a.osVersion == b.osVersion {
+                return (equal: true, shouldGoBefore: false)
+            }
+            return (equal: false, shouldGoBefore: a.osVersion < b.osVersion)
         }
         
-        //then sort, devices first and if match, connected first
+        //then sort, devices first and if match, then by name & os version
         let sortedDevices = filtered.sort { (a, b) -> Bool in
             
             let (equalDevices, goBeforeDevices) = sortDevices(a, b)
@@ -483,9 +492,14 @@ class BuildTemplateViewController: ConfigEditViewController, NSTableViewDataSour
                 return goBeforeDevices
             }
             
-            let (equalConnected, goBeforeConnected) = sortConnected(a, b)
-            if !equalConnected {
-                return goBeforeConnected
+            let (equalName, goBeforeName) = sortByName(a, b)
+            if !equalName {
+                return goBeforeName
+            }
+            
+            let (equalOSVersion, goBeforeOSVersion) = sortByOSVersion(a, b)
+            if !equalOSVersion {
+                return goBeforeOSVersion
             }
             return true
         }


### PR DESCRIPTION
The original sorting algorithm placed devices before simulators and
connected devices before disconnected devices.  It did not account for
device name and that made it difficult to find specific entries in a
long list.

This change places devices before simulators, then sorts by name and
OS version.  Connection status is no longer used to sort.

Here are the first five items on our Xcode server under the old sort:
- iPhone 4s 7.1
- iPhone 5 7.1
- iPhone 5s 7.1
- iPad 2 7.1
- iPad Retina 7.1

Here are the first five items on our Xcode server under the new sort:
- iPad 2 7.1
- iPad 2 8.0
- iPad 2 8.1
- iPad 2 8.2
- iPad 2 8.3

This pattern makes it much easier to manually select the devices used
by a build template.

Fixes #195 
