### PR TITLE
Xcode 7.3b1 API compatibility (9)

### DIFF
--- a/Podfile
+++ b/Podfile
@@ -3,7 +3,7 @@ use_frameworks!
 inhibit_all_warnings!
 
 def pods_for_errbody
-    pod 'BuildaUtils', '~> 0.2.2'
+    pod 'BuildaUtils', '~> 0.2.4'
 end
 
 def rac
@@ -12,7 +12,7 @@ end
 
 def also_xcode_pods
     pods_for_errbody
-    pod 'XcodeServerSDK', '~> 0.5.1'
+    pod 'XcodeServerSDK', '~> 0.5.4'
     pod 'ekgclient', '~> 0.3.0'
 end
 

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -1,6 +1,6 @@
 PODS:
   - Alamofire (2.0.0-beta.3)
-  - BuildaUtils (0.2.3)
+  - BuildaUtils (0.2.4)
   - CryptoSwift (0.1.1)
   - ekgclient (0.3.0):
     - Alamofire (= 2.0.0-beta.3)
@@ -22,27 +22,27 @@ PODS:
     - ReactiveCocoa/Core
     - Result (~> 0.6-beta.1)
   - Result (0.6.0-beta.6)
-  - XcodeServerSDK (0.5.2):
+  - XcodeServerSDK (0.5.4):
     - BuildaUtils (~> 0.2.3)
 
 DEPENDENCIES:
-  - BuildaUtils (~> 0.2.2)
+  - BuildaUtils (~> 0.2.4)
   - CryptoSwift
   - ekgclient (~> 0.3.0)
   - Ji (~> 1.2.0)
   - Nimble (~> 3.0.0)
   - ReactiveCocoa (~> 4.0.4-alpha-1)
-  - XcodeServerSDK (~> 0.5.1)
+  - XcodeServerSDK (~> 0.5.4)
 
 SPEC CHECKSUMS:
   Alamofire: 39dddb7d3725d1771b1d2f7099c8bd45bd83ffbb
-  BuildaUtils: ea53e9781ddd764d525b1c3bb98f68e22cc58170
+  BuildaUtils: c509ce20402656700006eb5ab80c735fbf2b3864
   CryptoSwift: c11640d3d66107efc8333e4131a5173f072b1d61
   ekgclient: 40f5d347e2ede450b3e50ac7c6bd84d96e7b84ad
   Ji: ddebb22f9ac445db6e884b66f78ea74fb135fdb7
   Nimble: 4c353d43735b38b545cbb4cb91504588eb5de926
   ReactiveCocoa: 618a2fc13d4ed80e380aa6fa56547cef43c7341d
   Result: dc390d0b58f9ec43fcd536f1ebdd130803cc6cbc
-  XcodeServerSDK: af33ec632aef355307489f9633aea78b59be0504
+  XcodeServerSDK: 38c2bbdbc8e1387480adde299c0dc4455f0af11b
 
 COCOAPODS: 0.39.0


### PR DESCRIPTION
Upgraded XcodeServerSDK to version 0.5.4 which works with the new API version number (no actual behavioral changes found yet).
