### PR TITLE
Swift 2.2, dependencies upgraded

### DIFF
--- a/BuildaGitServer/Base/BaseTypes.swift
+++ b/BuildaGitServer/Base/BaseTypes.swift
@@ -8,6 +8,7 @@
 
 import Foundation
 import ReactiveCocoa
+import Result
 
 public protocol BuildStatusCreator {
     func createStatusFromState(state: BuildState, description: String?, targetUrl: String?) -> StatusType

--- a/BuildaGitServer/BitBucket/BitBucketServer.swift
+++ b/BuildaGitServer/BitBucket/BitBucketServer.swift
@@ -9,6 +9,7 @@
 import Foundation
 import BuildaUtils
 import ReactiveCocoa
+import Result
 
 class BitBucketServer : GitServer {
     

--- a/BuildaGitServer/GitHub/GitHubServer.swift
+++ b/BuildaGitServer/GitHub/GitHubServer.swift
@@ -154,8 +154,7 @@ extension GitHubServer {
             //url
             var urlString = link[0].stringByTrimmingCharactersInSet(NSCharacterSet.whitespaceCharacterSet())
             if urlString.hasPrefix("<") && urlString.hasSuffix(">") {
-                urlString = urlString.substringWithRange(Range<String.Index>(start: urlString.startIndex.successor(),
-                    end: urlString.endIndex.predecessor()))
+                urlString = urlString[urlString.startIndex.successor() ..< urlString.endIndex.predecessor()]
             }
             
             //rel
@@ -167,8 +166,7 @@ extension GitHubServer {
             
             var relName = relComps[1]
             if relName.hasPrefix("\"") && relName.hasSuffix("\"") {
-                relName = relName.substringWithRange(Range<String.Index>(start: relName.startIndex.successor(),
-                    end: relName.endIndex.predecessor()))
+                relName = relName[relName.startIndex.successor() ..< relName.endIndex.predecessor()]
             }
             
             if

--- a/BuildaGitServer/GitServerPublic.swift
+++ b/BuildaGitServer/GitServerPublic.swift
@@ -10,6 +10,7 @@ import Foundation
 import BuildaUtils
 import Keys
 import ReactiveCocoa
+import Result
 
 public enum GitService: String {
     case GitHub = "github"

--- a/BuildaKit/Availability.swift
+++ b/BuildaKit/Availability.swift
@@ -8,6 +8,7 @@
 
 import Foundation
 import ReactiveCocoa
+import Result
 import BuildaUtils
 import XcodeServerSDK
 

--- a/BuildaKit/Project.swift
+++ b/BuildaKit/Project.swift
@@ -98,8 +98,8 @@ public class Project {
                 
                 let start = githubRange.endIndex.advancedBy(1)
                 let end = dotGitRange.startIndex
-                
-                let repoName = originalStringUrl.substringWithRange(Range<String.Index>(start: start, end: end))
+            
+                let repoName = originalStringUrl[start ..< end]
                 return repoName
         }
         return nil

--- a/BuildaKit/RACUtils.swift
+++ b/BuildaKit/RACUtils.swift
@@ -8,6 +8,7 @@
 
 import Foundation
 import ReactiveCocoa
+import Result
 
 public func flattenArray<T, E>(inProducer: SignalProducer<[T], E>) -> SignalProducer<T, E> {
     

--- a/BuildaKit/StorageManager.swift
+++ b/BuildaKit/StorageManager.swift
@@ -10,6 +10,7 @@ import Foundation
 import BuildaUtils
 import XcodeServerSDK
 import ReactiveCocoa
+import Result
 import BuildaGitServer
 
 public enum StorageManagerError: ErrorType {

--- a/BuildaKit/SyncerConfig.swift
+++ b/BuildaKit/SyncerConfig.swift
@@ -14,7 +14,9 @@ public typealias RefType = String
 public struct Ref {
     static func new() -> RefType {
         #if TESTING
-            return testIds[(counter++) % testIds.count]
+            let ref = testIds[counter % testIds.count]
+            counter += 1
+            return ref
         #else
             return NSUUID().UUIDString
         #endif

--- a/BuildaKit/SyncerManager.swift
+++ b/BuildaKit/SyncerManager.swift
@@ -8,6 +8,7 @@
 
 import Foundation
 import ReactiveCocoa
+import Result
 import XcodeServerSDK
 import BuildaHeartbeatKit
 import BuildaUtils

--- a/BuildaKit/SyncerProducerFactory.swift
+++ b/BuildaKit/SyncerProducerFactory.swift
@@ -8,6 +8,7 @@
 
 import Foundation
 import ReactiveCocoa
+import Result
 import XcodeServerSDK
 
 class SyncerProducerFactory {

--- a/BuildaKit/WorkspaceMetadata.swift
+++ b/BuildaKit/WorkspaceMetadata.swift
@@ -72,7 +72,7 @@ extension WorkspaceMetadata {
         //for SSH URLs we need to remove the git@ prefix to be properly parsable
         if urlString.hasPrefix("git@") {
             let s = urlString.startIndex
-            let range = Range<String.Index>(start: s, end: s.advancedBy(4))
+            let range = s ..< s.advancedBy(4)
             urlString = urlString.stringByReplacingCharactersInRange(range, withString: "")
         }
         

--- a/BuildaKitTests/SyncPair_PR_Bot_Tests.swift
+++ b/BuildaKitTests/SyncPair_PR_Bot_Tests.swift
@@ -16,12 +16,12 @@ import BuildaKit
 
 //for tuples, XCTAssert... doesn't work for them
 func XCTBAssertNil<T>(@autoclosure expression:  () -> T?, message: String = "Must be nil",
-    file: String = __FILE__, line: UInt = __LINE__) {
+    file: StaticString = __FILE__, line: UInt = __LINE__) {
     XCTAssert(expression() == nil, message, file:file, line:line);
 }
 
 func XCTBAssertNotNil<T>(@autoclosure expression:  () -> T?, message: String = "Must not be nil",
-    file: String = __FILE__, line: UInt = __LINE__) {
+    file: StaticString = __FILE__, line: UInt = __LINE__) {
         XCTAssert(expression() != nil, message, file:file, line:line);
 }
 

--- a/Buildasaur.xcodeproj/project.pbxproj
+++ b/Buildasaur.xcodeproj/project.pbxproj
@@ -1773,6 +1773,7 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				COMBINE_HIDPI_IMAGES = YES;
+				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
 				INFOPLIST_FILE = Buildasaur/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/../Frameworks";
 				MACOSX_DEPLOYMENT_TARGET = 10.11;
@@ -1788,6 +1789,7 @@
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_IDENTITY = "Developer ID Application: Jan Dvorsky (7BJ2984YDK)";
 				COMBINE_HIDPI_IMAGES = YES;
+				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
 				ENABLE_NS_ASSERTIONS = YES;
 				INFOPLIST_FILE = Buildasaur/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/../Frameworks";
@@ -1931,6 +1933,7 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				COMBINE_HIDPI_IMAGES = YES;
+				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
 				ENABLE_NS_ASSERTIONS = YES;
 				ENABLE_TESTABILITY = YES;
 				INFOPLIST_FILE = Buildasaur/Info.plist;

--- a/Buildasaur/BuildTemplateViewController.swift
+++ b/Buildasaur/BuildTemplateViewController.swift
@@ -12,6 +12,7 @@ import BuildaUtils
 import XcodeServerSDK
 import BuildaKit
 import ReactiveCocoa
+import Result
 
 protocol BuildTemplateViewControllerDelegate: class {
     func didCancelEditingOfBuildTemplate(template: BuildTemplate)

--- a/Buildasaur/ConfigEditViewController.swift
+++ b/Buildasaur/ConfigEditViewController.swift
@@ -11,6 +11,7 @@ import BuildaUtils
 import XcodeServerSDK
 import BuildaKit
 import ReactiveCocoa
+import Result
 
 class ConfigEditViewController: EditableViewController {
     

--- a/Buildasaur/DashboardViewController.swift
+++ b/Buildasaur/DashboardViewController.swift
@@ -9,6 +9,7 @@
 import Cocoa
 import BuildaKit
 import ReactiveCocoa
+import Result
 
 protocol EditeeDelegate: class, EmptyXcodeServerViewControllerDelegate, XcodeServerViewControllerDelegate, EmptyProjectViewControllerDelegate, ProjectViewControllerDelegate, EmptyBuildTemplateViewControllerDelegate, BuildTemplateViewControllerDelegate, SyncerViewControllerDelegate { }
 

--- a/Buildasaur/EditableViewController.swift
+++ b/Buildasaur/EditableViewController.swift
@@ -10,6 +10,7 @@ import Cocoa
 import BuildaUtils
 import BuildaKit
 import ReactiveCocoa
+import Result
 
 class EditableViewController: NSViewController {
     

--- a/Buildasaur/EmptyBuildTemplateViewController.swift
+++ b/Buildasaur/EmptyBuildTemplateViewController.swift
@@ -11,6 +11,7 @@ import BuildaKit
 import BuildaUtils
 import XcodeServerSDK
 import ReactiveCocoa
+import Result
 
 protocol EmptyBuildTemplateViewControllerDelegate: class {
     func didSelectBuildTemplate(buildTemplate: BuildTemplate)

--- a/Buildasaur/EmptyProjectViewController.swift
+++ b/Buildasaur/EmptyProjectViewController.swift
@@ -9,6 +9,7 @@
 import Cocoa
 import BuildaKit
 import ReactiveCocoa
+import Result
 import BuildaUtils
 
 protocol EmptyProjectViewControllerDelegate: class {

--- a/Buildasaur/EmptyXcodeServerViewController.swift
+++ b/Buildasaur/EmptyXcodeServerViewController.swift
@@ -11,6 +11,7 @@ import BuildaKit
 import BuildaUtils
 import XcodeServerSDK
 import ReactiveCocoa
+import Result
 
 protocol EmptyXcodeServerViewControllerDelegate: class {
     func didSelectXcodeServerConfig(config: XcodeServerConfig)

--- a/Buildasaur/RACUIExtensions.swift
+++ b/Buildasaur/RACUIExtensions.swift
@@ -9,6 +9,7 @@
 import Foundation
 import Cocoa
 import ReactiveCocoa
+import Result
 
 //taken from https://github.com/ColinEberhardt/ReactiveTwitterSearch/blob/82ab9d2595b07cbefd4c917ae643b568dd858119/ReactiveTwitterSearch/Util/UIKitExtensions.swift
 

--- a/Buildasaur/SyncerViewController.swift
+++ b/Buildasaur/SyncerViewController.swift
@@ -12,6 +12,7 @@ import BuildaUtils
 import XcodeServerSDK
 import BuildaKit
 import ReactiveCocoa
+import Result
 
 protocol SyncerViewControllerDelegate: class {
     

--- a/Buildasaur/SyncerViewModel.swift
+++ b/Buildasaur/SyncerViewModel.swift
@@ -9,6 +9,7 @@
 import Foundation
 import BuildaKit
 import ReactiveCocoa
+import Result
 
 struct SyncerStatePresenter {
     

--- a/Buildasaur/TriggerViewController.swift
+++ b/Buildasaur/TriggerViewController.swift
@@ -11,6 +11,7 @@ import XcodeServerSDK
 import BuildaUtils
 import BuildaKit
 import ReactiveCocoa
+import Result
 
 protocol TriggerViewControllerDelegate: class {
     func triggerViewControllerDidCancelEditingTrigger(trigger: TriggerConfig)

--- a/Podfile
+++ b/Podfile
@@ -20,12 +20,12 @@ def pods_for_errbody
 end
 
 def rac
-    pod 'ReactiveCocoa', '=4.0.0-RC.1'
+    pod 'ReactiveCocoa', '~> 4.0.1'
 end
 
 def also_xcode_pods
     pods_for_errbody
-    pod 'XcodeServerSDK', '~> 0.5.6'
+    pod 'XcodeServerSDK', '~> 0.5.7'
     pod 'ekgclient', '~> 0.3.1'
 end
 
@@ -39,7 +39,8 @@ def buildasaur_app_pods
 end
 
 def test_pods
-    pod 'Nimble', '~> 3.0.0'
+    # pod 'Nimble', '~> 3.0.0'
+    pod 'Nimble', :git => "https://github.com/Quick/Nimble.git", :commit => "b9256b0bdecc4ef1f659b7663dcd3aab6f43fb5f"
 end
 
 target 'Buildasaur' do

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -16,23 +16,23 @@ PODS:
   - Ji/Ji-libxml (1.2.0)
   - KeychainAccess (2.3.3)
   - Keys (1.0.0)
-  - Nimble (3.0.0)
+  - Nimble (3.1.0)
   - OAuthSwift (0.5.0)
-  - ReactiveCocoa (4.0.0-RC.1):
-    - ReactiveCocoa/UI (= 4.0.0-RC.1)
-    - Result (~> 1.0)
-  - ReactiveCocoa/Core (4.0.0-RC.1):
+  - ReactiveCocoa (4.0.1):
+    - ReactiveCocoa/UI (= 4.0.1)
+    - Result (~> 1.0.2)
+  - ReactiveCocoa/Core (4.0.1):
     - ReactiveCocoa/no-arc
-    - Result (~> 1.0)
-  - ReactiveCocoa/no-arc (4.0.0-RC.1):
-    - Result (~> 1.0)
-  - ReactiveCocoa/UI (4.0.0-RC.1):
+    - Result (~> 1.0.2)
+  - ReactiveCocoa/no-arc (4.0.1):
+    - Result (~> 1.0.2)
+  - ReactiveCocoa/UI (4.0.1):
     - ReactiveCocoa/Core
-    - Result (~> 1.0)
-  - Result (1.0.1)
+    - Result (~> 1.0.2)
+  - Result (1.0.2)
   - Sparkle (1.13.1)
   - SwiftSafe (0.1)
-  - XcodeServerSDK (0.5.6):
+  - XcodeServerSDK (0.5.7):
     - BuildaUtils (~> 0.2.3)
 
 DEPENDENCIES:
@@ -44,15 +44,23 @@ DEPENDENCIES:
   - Ji (~> 1.2.0)
   - KeychainAccess
   - Keys (from `Pods/CocoaPodsKeys`)
-  - Nimble (~> 3.0.0)
+  - Nimble (from `https://github.com/Quick/Nimble.git`, commit `b9256b0bdecc4ef1f659b7663dcd3aab6f43fb5f`)
   - OAuthSwift
-  - ReactiveCocoa (= 4.0.0-RC.1)
+  - ReactiveCocoa (~> 4.0.1)
   - Sparkle
-  - XcodeServerSDK (~> 0.5.6)
+  - XcodeServerSDK (~> 0.5.7)
 
 EXTERNAL SOURCES:
   Keys:
     :path: Pods/CocoaPodsKeys
+  Nimble:
+    :commit: b9256b0bdecc4ef1f659b7663dcd3aab6f43fb5f
+    :git: https://github.com/Quick/Nimble.git
+
+CHECKOUT OPTIONS:
+  Nimble:
+    :commit: b9256b0bdecc4ef1f659b7663dcd3aab6f43fb5f
+    :git: https://github.com/Quick/Nimble.git
 
 SPEC CHECKSUMS:
   Alamofire: 39dddb7d3725d1771b1d2f7099c8bd45bd83ffbb
@@ -65,14 +73,14 @@ SPEC CHECKSUMS:
   Ji: ddebb22f9ac445db6e884b66f78ea74fb135fdb7
   KeychainAccess: 9b7e49e48277e329b1b3195e54697ed313d30acf
   Keys: 9c35bf00f612ee1d48556f4a4b9b4551e224e90f
-  Nimble: 4c353d43735b38b545cbb4cb91504588eb5de926
+  Nimble: eb2a9b164b9a3f16df6581c692a0bfced7d072a4
   OAuthSwift: f2e0de083739da5697be095c9af2671242a4ed8b
-  ReactiveCocoa: 2b0f654beb7642b82cfd3fdb845205ae9889422c
-  Result: caef80340451e1f07492fa1e89117f83613bce24
+  ReactiveCocoa: f7011630aee4deeb16352fcb1b50d6bde9db4f90
+  Result: dd3dd71af3fa2e262f1a999e14fba2c25ec14f16
   Sparkle: 2fbd47b869621d1e679c7554e3e19dda02104818
   SwiftSafe: 77ffd12b02678790bec1ef56a2d14ec5036f1fd6
-  XcodeServerSDK: 6300badc4a799da9ad6e970b366eda18d4a47bda
+  XcodeServerSDK: 34e18e12f683fec69ad0a1897d1f5447a660a927
 
-PODFILE CHECKSUM: 719a0c9e06ae8dea3e42db2d1c92a2218365900c
+PODFILE CHECKSUM: 4d479fa3b979a6faa03462e751aa08a2b4774660
 
 COCOAPODS: 1.0.0.beta.3


### PR DESCRIPTION
Updates for Swift 2.2, upgraded RAC to 4.0.1, XcodeServerSDK to 0.5.7, Nimble to master version of 3.1.0
