### PR TITLE
Buildasaur Github issue #244

### DIFF
--- a/BuildaKit/Project.swift
+++ b/BuildaKit/Project.swift
@@ -93,8 +93,8 @@ public class Project {
         */
         
         let serviceUrl = service.hostname().lowercaseString
-        if let githubRange = stringUrl.rangeOfString(serviceUrl, options: NSStringCompareOptions(), range: nil, locale: nil),
-            let dotGitRange = stringUrl.rangeOfString(".git", options: NSStringCompareOptions.BackwardsSearch, range: nil, locale: nil) {
+        let dotGitRange = stringUrl.rangeOfString(".git", options: NSStringCompareOptions.BackwardsSearch, range: nil, locale: nil) ?? Range(start: stringUrl.endIndex, end: stringUrl.endIndex)
+        if let githubRange = stringUrl.rangeOfString(serviceUrl, options: NSStringCompareOptions(), range: nil, locale: nil){
                 
                 let start = githubRange.endIndex.advancedBy(1)
                 let end = dotGitRange.startIndex


### PR DESCRIPTION
Sometimes github strings do not have ".git" attached to the end.
I have a fix that will address both kinds of strings to extract the repo name.

This change is kind of a hacky way to make a Range object, but hey it works.
