### PR TITLE
Added ability to create syncers for tvOS projects

### DIFF
--- a/BuildaKit/XcodeDeviceParser.swift
+++ b/BuildaKit/XcodeDeviceParser.swift
@@ -16,6 +16,7 @@ public class XcodeDeviceParser {
         case iPhoneOS = "iphoneos"
         case macOSX = "macosx"
         case watchOS = "watchos"
+        case tvOS = "appletvos"
         
         public func toPlatformType() -> DevicePlatform.PlatformType {
             switch self {
@@ -25,6 +26,8 @@ public class XcodeDeviceParser {
                 return .OSX
             case .watchOS:
                 return .watchOS
+            case .tvOS:
+                return .tvOS
             }
         }
     }


### PR DESCRIPTION
This is enough to allow creation of syncers for tvOS targets. Bots are created and executed as expected--see [ioveracker/Zen PR #3](https://github.com/ioveracker/Zen/pull/3) for an example. 

There is still the issue of how to build both iOS and tvOS targets, or conditionally build one target or the other based on the PR title or something else. But for now, this will suffice for creating syncers that build tvOS projects.
