### PR TITLE
Added support for repo URLs prefixed with ssh://

### DIFF
--- a/BuildaKitTests/WorkspaceMetadataTests.swift
+++ b/BuildaKitTests/WorkspaceMetadataTests.swift
@@ -1,0 +1,73 @@
+//
+//  WorkspaceMetadataTests.swift
+//  Buildasaur
+//
+//  Created by Isaac Overacker on 5/6/16.
+//  Copyright © 2016 Honza Dvorsky. All rights reserved.
+//
+
+import XCTest
+import Nimble
+@testable import BuildaKit
+import BuildaGitServer
+
+class WorkspaceMetadataTests: XCTestCase {
+
+    func help_test_parse_with(urlString url: String, expectedCheckoutType: CheckoutType, expectedGitService: GitService) {
+        guard let (checkoutType, service) = WorkspaceMetadata.parse(url) else {
+            XCTFail("Failed to parse URL string: \(url)")
+            return
+        }
+
+        expect(checkoutType) == expectedCheckoutType
+        expect(service) == expectedGitService
+    }
+
+    // MARK: GitHub
+
+    func test_parse_SSH_withSlash_github() {
+        help_test_parse_with(urlString: "ssh://git@github.com/organization/repo",
+                             expectedCheckoutType: CheckoutType.SSH,
+                             expectedGitService: GitService.GitHub)
+    }
+
+    func test_parse_noSSH_withColon_github() {
+        help_test_parse_with(urlString: "git@github.com:organization/repo",
+                             expectedCheckoutType: CheckoutType.SSH,
+                             expectedGitService: GitService.GitHub)
+    }
+
+    // MARK: BitBucket
+
+    func test_parse_SSH_withSlash_bitbucket() {
+        help_test_parse_with(urlString: "ssh://git@bitbucket.org/organization/repo",
+                             expectedCheckoutType: CheckoutType.SSH,
+                             expectedGitService: GitService.BitBucket)
+    }
+
+    func test_parse_noSSH_withColon_bitbucket() {
+        help_test_parse_with(urlString: "git@bitbucket.org:organization/repo",
+                             expectedCheckoutType: CheckoutType.SSH,
+                             expectedGitService: GitService.BitBucket)
+    }
+
+    // MARK: HTTP
+
+    func test_parse_HTTPS() {
+        expect(WorkspaceMetadata.parse("https://github.com/organization/repo")).to(beNil())
+    }
+
+    func test_parse_HTTP() {
+        expect(WorkspaceMetadata.parse("http://github.com/organization/repo")).to(beNil())
+    }
+
+    func test_parse_implicitHTTP() {
+        expect(WorkspaceMetadata.parse("github.com/organization/repo")).to(beNil())
+    }
+
+    // MARK: Git protocol
+
+    func test_parse_git() {
+        expect(WorkspaceMetadata.parse("git://github.com/organization/repo")).to(beNil())
+    }
+}

--- a/Buildasaur.xcodeproj/project.pbxproj
+++ b/Buildasaur.xcodeproj/project.pbxproj
@@ -157,6 +157,7 @@
 		3AF090B81B1134AA0058567F /* BranchWatchingViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3AF090B71B1134AA0058567F /* BranchWatchingViewController.swift */; };
 		3AF1B1241AAC7CA500917EF3 /* SyncerViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3AF1B1231AAC7CA500917EF3 /* SyncerViewController.swift */; };
 		775501D89C0E4D209E6EE5D0 /* Pods_BuildaGitServer.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = B9139F7877761955F17C535E /* Pods_BuildaGitServer.framework */; };
+		785688011CDD4843009EEB72 /* WorkspaceMetadataTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 785688001CDD4843009EEB72 /* WorkspaceMetadataTests.swift */; };
 		D59A4C6EEE903468E69AEA81 /* Pods_BuildaKitTests.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 4EC43508E8A4F9D6E5ED0126 /* Pods_BuildaKitTests.framework */; };
 		E9F513792E8C95C43A68D1CD /* Pods_BuildaKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 7827BDC6B1752C193A0EAA05 /* Pods_BuildaKit.framework */; };
 /* End PBXBuildFile section */
@@ -382,6 +383,7 @@
 		4EC43508E8A4F9D6E5ED0126 /* Pods_BuildaKitTests.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_BuildaKitTests.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		6A0C42D6343BC2A4C4C899AB /* Pods-BuildaHeartbeatKit.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-BuildaHeartbeatKit.release.xcconfig"; path = "Pods/Target Support Files/Pods-BuildaHeartbeatKit/Pods-BuildaHeartbeatKit.release.xcconfig"; sourceTree = "<group>"; };
 		7827BDC6B1752C193A0EAA05 /* Pods_BuildaKit.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_BuildaKit.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		785688001CDD4843009EEB72 /* WorkspaceMetadataTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = WorkspaceMetadataTests.swift; sourceTree = "<group>"; };
 		8176576B54DB918274B10F51 /* Pods-Buildasaur.testing.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Buildasaur.testing.xcconfig"; path = "Pods/Target Support Files/Pods-Buildasaur/Pods-Buildasaur.testing.xcconfig"; sourceTree = "<group>"; };
 		8FA09FE729BC440366D74E2E /* Pods_Buildasaur.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_Buildasaur.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		906BE3BD7A02D5A19E6E5269 /* Pods-Buildasaur.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Buildasaur.debug.xcconfig"; path = "Pods/Target Support Files/Pods-Buildasaur/Pods-Buildasaur.debug.xcconfig"; sourceTree = "<group>"; };
@@ -636,6 +638,7 @@
 				3AD5D2E91BD02144008DBB45 /* GitHubSummaryBuilderTests.swift */,
 				3ACBADDA1B5ADE1400204457 /* SyncerTests.swift */,
 				3ACBADDB1B5ADE1400204457 /* SyncPair_PR_Bot_Tests.swift */,
+				785688001CDD4843009EEB72 /* WorkspaceMetadataTests.swift */,
 				3A9D741E1BCBF86900DCA23C /* Migration */,
 			);
 			path = BuildaKitTests;
@@ -1557,6 +1560,7 @@
 			files = (
 				3ACBADD71B5ADE0E00204457 /* MockHelpers.swift in Sources */,
 				3AD5D2EA1BD02144008DBB45 /* GitHubSummaryBuilderTests.swift in Sources */,
+				785688011CDD4843009EEB72 /* WorkspaceMetadataTests.swift in Sources */,
 				3ACBADDE1B5ADE1400204457 /* SyncerTests.swift in Sources */,
 				3ACBADDF1B5ADE1400204457 /* SyncPair_PR_Bot_Tests.swift in Sources */,
 				3ACBADDC1B5ADE1400204457 /* Mocks.swift in Sources */,


### PR DESCRIPTION
From the [Git Book](https://git-scm.com/book/en/v2/Git-on-the-Server-The-Protocols#The-SSH-Protocol):

> To clone a Git repository over SSH, you can specify ssh:// URL like this:
> 
> `$ git clone ssh://user@server/project.git`
> 
> Or you can use the shorter scp-like syntax for the SSH protocol:
> 
> `$ git clone user@server:project.git`

Instead of depending on the url to start with "git@", the checkout type and git service are now determined using `NSURL`'s `resourceSpecifier` and `scheme` properties without manipulating the original URL string.

I just noticed that there are small changes to the `parse` function in #251, but the merge shouldn't be tricky.
