### PR TITLE
Add ability to reuse trigger in different templates;

### DIFF
--- a/BuildaKit/CommonExtensions.swift
+++ b/BuildaKit/CommonExtensions.swift
@@ -125,6 +125,15 @@ extension NSDictionary {
     }
 }
 
+extension Dictionary {
+    
+    public mutating func merge<S: SequenceType where S.Generator.Element == (Key,Value)> (other: S) {
+        for (key, value) in other {
+            self[key] = value
+        }
+    }
+}
+
 extension Array {
     
     public func dictionarifyWithKey(key: (item: Element) -> String) -> [String: Element] {

--- a/BuildaKitTests/ExtensionTests.swift
+++ b/BuildaKitTests/ExtensionTests.swift
@@ -1,0 +1,23 @@
+//
+//  ExtensionTests.swift
+//  Buildasaur
+//
+//  Created by Anton Domashnev on 25/06/16.
+//  Copyright © 2016 Honza Dvorsky. All rights reserved.
+//
+
+import XCTest
+
+class ExtensionTests: XCTestCase {
+    
+    func testMergeShouldMergeTwoDictionaries() {
+        var dictionary1: [String: String] = ["A": "B", "A1": "B1", "A2": "B2" ]
+        let dictionary2: [String: String] = ["A2": "B2", "A3": "B3", "A4": "B4" ]
+        let expectedMergedDictionary: [String: String] = ["A": "B", "A1": "B1", "A2": "B2", "A3": "B3", "A4": "B4" ]
+        
+        dictionary1.merge(dictionary2)
+        
+        XCTAssertEqual(dictionary1, expectedMergedDictionary)
+    }
+    
+}

--- a/Buildasaur.xcodeproj/project.pbxproj
+++ b/Buildasaur.xcodeproj/project.pbxproj
@@ -156,6 +156,8 @@
 		3AED13151C52A1A300E3B7FF /* SecurePersistence.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3AED13141C52A1A300E3B7FF /* SecurePersistence.swift */; };
 		3AF090B81B1134AA0058567F /* BranchWatchingViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3AF090B71B1134AA0058567F /* BranchWatchingViewController.swift */; };
 		3AF1B1241AAC7CA500917EF3 /* SyncerViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3AF1B1231AAC7CA500917EF3 /* SyncerViewController.swift */; };
+		6DF2EAFA1D1C6DDF006FC52B /* SelectTriggerViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6DF2EAF91D1C6DDF006FC52B /* SelectTriggerViewController.swift */; };
+		6DF2EB301D1EB0F0006FC52B /* ExtensionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6DF2EB2F1D1EB0F0006FC52B /* ExtensionTests.swift */; };
 		775501D89C0E4D209E6EE5D0 /* Pods_BuildaGitServer.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = B9139F7877761955F17C535E /* Pods_BuildaGitServer.framework */; };
 		785688011CDD4843009EEB72 /* WorkspaceMetadataTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 785688001CDD4843009EEB72 /* WorkspaceMetadataTests.swift */; };
 		D59A4C6EEE903468E69AEA81 /* Pods_BuildaKitTests.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 4EC43508E8A4F9D6E5ED0126 /* Pods_BuildaKitTests.framework */; };
@@ -382,6 +384,8 @@
 		4A4FCE02D4B5A180AAF85C12 /* Pods-BuildaGitServer.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-BuildaGitServer.debug.xcconfig"; path = "Pods/Target Support Files/Pods-BuildaGitServer/Pods-BuildaGitServer.debug.xcconfig"; sourceTree = "<group>"; };
 		4EC43508E8A4F9D6E5ED0126 /* Pods_BuildaKitTests.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_BuildaKitTests.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		6A0C42D6343BC2A4C4C899AB /* Pods-BuildaHeartbeatKit.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-BuildaHeartbeatKit.release.xcconfig"; path = "Pods/Target Support Files/Pods-BuildaHeartbeatKit/Pods-BuildaHeartbeatKit.release.xcconfig"; sourceTree = "<group>"; };
+		6DF2EAF91D1C6DDF006FC52B /* SelectTriggerViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SelectTriggerViewController.swift; sourceTree = "<group>"; };
+		6DF2EB2F1D1EB0F0006FC52B /* ExtensionTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ExtensionTests.swift; sourceTree = "<group>"; };
 		7827BDC6B1752C193A0EAA05 /* Pods_BuildaKit.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_BuildaKit.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		785688001CDD4843009EEB72 /* WorkspaceMetadataTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = WorkspaceMetadataTests.swift; sourceTree = "<group>"; };
 		8176576B54DB918274B10F51 /* Pods-Buildasaur.testing.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Buildasaur.testing.xcconfig"; path = "Pods/Target Support Files/Pods-Buildasaur/Pods-Buildasaur.testing.xcconfig"; sourceTree = "<group>"; };
@@ -639,6 +643,7 @@
 				3ACBADDA1B5ADE1400204457 /* SyncerTests.swift */,
 				3ACBADDB1B5ADE1400204457 /* SyncPair_PR_Bot_Tests.swift */,
 				785688001CDD4843009EEB72 /* WorkspaceMetadataTests.swift */,
+				6DF2EB2F1D1EB0F0006FC52B /* ExtensionTests.swift */,
 				3A9D741E1BCBF86900DCA23C /* Migration */,
 			);
 			path = BuildaKitTests;
@@ -779,6 +784,7 @@
 				3AF1B1231AAC7CA500917EF3 /* SyncerViewController.swift */,
 				3AF090B71B1134AA0058567F /* BranchWatchingViewController.swift */,
 				3A5B04AF1AB5144700F60536 /* ManualBotManagementViewController.swift */,
+				6DF2EAF91D1C6DDF006FC52B /* SelectTriggerViewController.swift */,
 			);
 			name = Editables;
 			sourceTree = "<group>";
@@ -1460,6 +1466,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				3A9109BF1BC29E0A00C2AECA /* EditorViewControllerFactory.swift in Sources */,
+				6DF2EAFA1D1C6DDF006FC52B /* SelectTriggerViewController.swift in Sources */,
 				3A0FF5A01BBFDA7E00FB8051 /* RACUIExtensions.swift in Sources */,
 				3AE0AB2B1BB991AB00A52D20 /* SyncerViewModel.swift in Sources */,
 				3AAA1B761AAC504700FA1598 /* XcodeServerViewController.swift in Sources */,
@@ -1564,6 +1571,7 @@
 				3ACBADDE1B5ADE1400204457 /* SyncerTests.swift in Sources */,
 				3ACBADDF1B5ADE1400204457 /* SyncPair_PR_Bot_Tests.swift in Sources */,
 				3ACBADDC1B5ADE1400204457 /* Mocks.swift in Sources */,
+				6DF2EB301D1EB0F0006FC52B /* ExtensionTests.swift in Sources */,
 				3A9D74201BCBF87900DCA23C /* MigrationTests.swift in Sources */,
 				3A7F0CC81BC1508C0079A511 /* GeneralTests.swift in Sources */,
 			);

--- a/Buildasaur/Base.lproj/Main.storyboard
+++ b/Buildasaur/Base.lproj/Main.storyboard
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<document type="com.apple.InterfaceBuilder3.Cocoa.Storyboard.XIB" version="3.0" toolsVersion="10089" systemVersion="15E33e" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none" useAutolayout="YES">
+<document type="com.apple.InterfaceBuilder3.Cocoa.Storyboard.XIB" version="3.0" toolsVersion="10117" systemVersion="15F34" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none" useAutolayout="YES">
     <dependencies>
         <deployment identifier="macosx"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="10089"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="10117"/>
         <capability name="Aspect ratio constraints" minToolsVersion="5.1"/>
         <capability name="stacking Non-gravity area distributions on NSStackView" minToolsVersion="7.0" minSystemVersion="10.11"/>
     </dependencies>
@@ -721,7 +721,7 @@
                                                     <tableColumnResizingMask key="resizingMask" resizeWithTable="YES" userResizable="YES"/>
                                                     <prototypeCellViews>
                                                         <tableCellView identifier="xcs_host" id="T5c-UH-Kcx">
-                                                            <rect key="frame" x="104" y="1" width="130" height="17"/>
+                                                            <rect key="frame" x="104.62939888871806" y="1" width="130" height="17"/>
                                                             <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                                                             <subviews>
                                                                 <textField verticalHuggingPriority="750" horizontalCompressionResistancePriority="250" translatesAutoresizingMaskIntoConstraints="NO" id="chB-Jy-cxW">
@@ -758,7 +758,7 @@
                                                     <tableColumnResizingMask key="resizingMask" resizeWithTable="YES" userResizable="YES"/>
                                                     <prototypeCellViews>
                                                         <tableCellView identifier="project_name" id="VxK-bY-IC3">
-                                                            <rect key="frame" x="237" y="1" width="160" height="17"/>
+                                                            <rect key="frame" x="239.29432564408523" y="1" width="160" height="17"/>
                                                             <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                                                             <subviews>
                                                                 <textField verticalHuggingPriority="750" horizontalCompressionResistancePriority="250" translatesAutoresizingMaskIntoConstraints="NO" id="28J-1B-dEw">
@@ -795,7 +795,7 @@
                                                     <tableColumnResizingMask key="resizingMask" resizeWithTable="YES" userResizable="YES"/>
                                                     <prototypeCellViews>
                                                         <tableCellView identifier="build_template" id="JE6-3o-Px5">
-                                                            <rect key="frame" x="400" y="1" width="130" height="17"/>
+                                                            <rect key="frame" x="401.54638828091822" y="1" width="130" height="17"/>
                                                             <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                                                             <subviews>
                                                                 <textField verticalHuggingPriority="750" horizontalCompressionResistancePriority="250" translatesAutoresizingMaskIntoConstraints="NO" id="Kfd-Lh-L1f">
@@ -831,7 +831,7 @@
                                                     <tableColumnResizingMask key="resizingMask" resizeWithTable="YES" userResizable="YES"/>
                                                     <prototypeCellViews>
                                                         <button identifier="control" verticalHuggingPriority="750" id="uVE-l3-mpn" customClass="BuildaNSButton" customModule="Buildasaur" customModuleProvider="target">
-                                                            <rect key="frame" x="533" y="1" width="80" height="32"/>
+                                                            <rect key="frame" x="536.21131503628544" y="1" width="80" height="32"/>
                                                             <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                                                             <buttonCell key="cell" type="push" title="Button" bezelStyle="rounded" alignment="center" borderStyle="border" imageScaling="proportionallyDown" inset="2" id="3hr-hy-pJR">
                                                                 <behavior key="behavior" pushIn="YES" lightByBackground="YES" lightByGray="YES"/>
@@ -856,7 +856,7 @@
                                                     <tableColumnResizingMask key="resizingMask" resizeWithTable="YES" userResizable="YES"/>
                                                     <prototypeCellViews>
                                                         <button identifier="edit" verticalHuggingPriority="750" id="vsh-hH-b23" customClass="BuildaNSButton" customModule="Buildasaur" customModuleProvider="target">
-                                                            <rect key="frame" x="616" y="1" width="80" height="32"/>
+                                                            <rect key="frame" x="619.1503620139041" y="1" width="80" height="32"/>
                                                             <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                                                             <buttonCell key="cell" type="push" title="Button" bezelStyle="rounded" alignment="center" borderStyle="border" imageScaling="proportionallyDown" inset="2" id="fti-Hu-uEW">
                                                                 <behavior key="behavior" pushIn="YES" lightByBackground="YES" lightByGray="YES"/>
@@ -1111,7 +1111,7 @@ Gw
                 </viewController>
                 <customObject id="HTT-4s-5b9" userLabel="First Responder" customClass="NSResponder" sceneMemberID="firstResponder"/>
             </objects>
-            <point key="canvasLocation" x="128" y="311"/>
+            <point key="canvasLocation" x="327" y="73"/>
         </scene>
         <!--Xcode Server View Controller-->
         <scene sceneID="tJp-HU-7xF">
@@ -1897,7 +1897,7 @@ Gw
                                             </textField>
                                             <popUpButton verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="zZG-wO-VNy">
                                                 <rect key="frame" x="69" y="-3" width="355" height="26"/>
-                                                <popUpButtonCell key="cell" type="push" title="Build Schedule" bezelStyle="rounded" alignment="left" lineBreakMode="truncatingTail" state="on" borderStyle="borderAndBezel" imageScaling="proportionallyDown" inset="2" selectedItem="7eU-wC-xF6" id="u43-4v-qLr">
+                                                <popUpButtonCell key="cell" type="push" title="Build Schedule" bezelStyle="rounded" alignment="left" lineBreakMode="truncatingTail" state="on" borderStyle="borderAndBezel" imageScaling="proportionallyDown" inset="2" preferredEdge="maxX" selectedItem="7eU-wC-xF6" id="u43-4v-qLr">
                                                     <behavior key="behavior" lightByBackground="YES" lightByGray="YES"/>
                                                     <font key="font" metaFont="menu"/>
                                                     <menu key="menu" id="94W-IT-C0p">
@@ -1979,7 +1979,7 @@ Gw
                                                         <constraints>
                                                             <constraint firstAttribute="width" constant="30" id="fOe-4Y-yQH"/>
                                                         </constraints>
-                                                        <buttonCell key="cell" type="push" title="+" bezelStyle="rounded" alignment="center" borderStyle="border" imageScaling="proportionallyDown" inset="2" id="jBO-WC-rqd">
+                                                        <buttonCell key="cell" type="push" title="+" bezelStyle="rounded" alignment="center" borderStyle="border" inset="2" id="jBO-WC-rqd">
                                                             <behavior key="behavior" pushIn="YES" lightByBackground="YES" lightByGray="YES"/>
                                                             <font key="font" metaFont="system"/>
                                                         </buttonCell>
@@ -2291,6 +2291,7 @@ Gw
                         <outlet property="testDevicesStackItem" destination="VmW-fk-we2" id="v5V-yw-cr0"/>
                         <outlet property="triggersTableView" destination="3LH-7K-zWF" id="mJs-5d-eR7"/>
                         <segue destination="761-zL-6B5" kind="sheet" identifier="showTrigger" id="lK8-ED-l22"/>
+                        <segue destination="jsB-SK-wde" kind="sheet" identifier="selectTriggers" id="sIl-XX-j8L"/>
                     </connections>
                 </viewController>
                 <customObject id="8lF-Xs-NXI" userLabel="First Responder" customClass="NSResponder" sceneMemberID="firstResponder"/>
@@ -2300,7 +2301,7 @@ Gw
         <!--Trigger View Controller-->
         <scene sceneID="X6G-px-x7q">
             <objects>
-                <viewController id="761-zL-6B5" customClass="TriggerViewController" customModule="Buildasaur" customModuleProvider="target" sceneMemberID="viewController">
+                <viewController storyboardIdentifier="triggerViewController" id="761-zL-6B5" customClass="TriggerViewController" customModule="Buildasaur" customModuleProvider="target" sceneMemberID="viewController">
                     <view key="view" id="Mm4-9X-Wd0">
                         <rect key="frame" x="0.0" y="0.0" width="500" height="440"/>
                         <autoresizingMask key="autoresizingMask"/>
@@ -2614,7 +2615,7 @@ Gw
                                             <real value="3.4028234663852886e+38"/>
                                         </customSpacing>
                                     </stackView>
-                                    <stackView distribution="fillEqually" orientation="horizontal" alignment="top" spacing="20" horizontalStackHuggingPriority="249.99998474121094" verticalStackHuggingPriority="249.99998474121094" detachesHiddenViews="YES" translatesAutoresizingMaskIntoConstraints="NO" id="Yy1-w8-4AT">
+                                    <stackView distribution="fillEqually" orientation="horizontal" alignment="top" spacing="20" horizontalStackHuggingPriority="249.99998474121094" verticalStackHuggingPriority="249.99998474121094" misplaced="YES" detachesHiddenViews="YES" translatesAutoresizingMaskIntoConstraints="NO" id="Yy1-w8-4AT">
                                         <rect key="frame" x="95" y="0.0" width="220" height="22"/>
                                         <subviews>
                                             <button verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="IQl-Cn-uMh">
@@ -2690,6 +2691,7 @@ Gw
                     <connections>
                         <outlet property="bodyDescriptionLabel" destination="BR5-sm-q4K" id="ZAK-1F-W16"/>
                         <outlet property="bodyTextField" destination="fZp-9N-XxC" id="ldo-z9-jhl"/>
+                        <outlet property="cancelButton" destination="OSY-UI-pFu" id="lD4-Mw-axR"/>
                         <outlet property="conditionAnalyzerWarningsCheckbox" destination="Bh1-0A-Uao" id="81m-Js-RzA"/>
                         <outlet property="conditionBuildErrorsCheckbox" destination="pC0-Oh-4a3" id="WC7-jf-vJb"/>
                         <outlet property="conditionFailingTestsCheckbox" destination="m1A-FT-vVT" id="HQX-WK-dnA"/>
@@ -2709,7 +2711,7 @@ Gw
                 </viewController>
                 <customObject id="fyY-Kc-dNd" userLabel="First Responder" customClass="NSResponder" sceneMemberID="firstResponder"/>
             </objects>
-            <point key="canvasLocation" x="1689" y="980"/>
+            <point key="canvasLocation" x="1422" y="1018"/>
         </scene>
         <!--Syncer View Controller-->
         <scene sceneID="N2h-cU-h0l">
@@ -3529,6 +3531,174 @@ Gw
                 <customObject id="7R7-Ka-TRB" userLabel="First Responder" customClass="NSResponder" sceneMemberID="firstResponder"/>
             </objects>
             <point key="canvasLocation" x="1071" y="450"/>
+        </scene>
+        <!--Select Trigger View Controller-->
+        <scene sceneID="biB-h3-rUK">
+            <objects>
+                <viewController id="jsB-SK-wde" customClass="SelectTriggerViewController" customModule="Buildasaur" customModuleProvider="target" sceneMemberID="viewController">
+                    <view key="view" id="iga-ba-WIk">
+                        <rect key="frame" x="0.0" y="0.0" width="500" height="440"/>
+                        <autoresizingMask key="autoresizingMask"/>
+                        <subviews>
+                            <customView translatesAutoresizingMaskIntoConstraints="NO" id="KsX-bi-gGE">
+                                <rect key="frame" x="0.0" y="0.0" width="500" height="440"/>
+                                <subviews>
+                                    <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="axw-TQ-grG">
+                                        <rect key="frame" x="176" y="398" width="147" height="22"/>
+                                        <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" alignment="center" title="Available triggers" id="36m-qX-SJb">
+                                            <font key="font" metaFont="system" size="18"/>
+                                            <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
+                                            <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
+                                        </textFieldCell>
+                                    </textField>
+                                    <scrollView autohidesScrollers="YES" horizontalLineScroll="19" horizontalPageScroll="10" verticalLineScroll="19" verticalPageScroll="10" usesPredominantAxisScrolling="NO" translatesAutoresizingMaskIntoConstraints="NO" id="nCz-IJ-jMn">
+                                        <rect key="frame" x="50" y="60" width="400" height="330"/>
+                                        <clipView key="contentView" id="LG0-v8-FSZ">
+                                            <rect key="frame" x="1" y="1" width="398" height="328"/>
+                                            <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+                                            <subviews>
+                                                <tableView verticalHuggingPriority="750" allowsExpansionToolTips="YES" columnAutoresizingStyle="lastColumnOnly" selectionHighlightStyle="none" alternatingRowBackgroundColors="YES" columnReordering="NO" multipleSelection="NO" autosaveColumns="NO" typeSelect="NO" id="tI3-HF-LAH">
+                                                    <rect key="frame" x="0.0" y="0.0" width="398" height="328"/>
+                                                    <autoresizingMask key="autoresizingMask"/>
+                                                    <size key="intercellSpacing" width="3" height="2"/>
+                                                    <color key="backgroundColor" name="controlBackgroundColor" catalog="System" colorSpace="catalog"/>
+                                                    <color key="gridColor" name="gridColor" catalog="System" colorSpace="catalog"/>
+                                                    <tableColumns>
+                                                        <tableColumn identifier="selected" width="20" minWidth="20" maxWidth="800" id="2An-gN-xMe">
+                                                            <tableHeaderCell key="headerCell" lineBreakMode="truncatingTail" borderStyle="border" alignment="left">
+                                                                <font key="font" metaFont="smallSystem"/>
+                                                                <color key="textColor" name="headerTextColor" catalog="System" colorSpace="catalog"/>
+                                                                <color key="backgroundColor" name="headerColor" catalog="System" colorSpace="catalog"/>
+                                                            </tableHeaderCell>
+                                                            <buttonCell key="dataCell" type="check" bezelStyle="regularSquare" imagePosition="only" alignment="center" inset="2" id="W7d-oh-Vqt">
+                                                                <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
+                                                                <font key="font" metaFont="system"/>
+                                                                <connections>
+                                                                    <action selector="triggersTableViewRowCheckboxTapped:" target="jsB-SK-wde" id="z4q-US-9EK"/>
+                                                                </connections>
+                                                            </buttonCell>
+                                                            <tableColumnResizingMask key="resizingMask" resizeWithTable="YES" userResizable="YES"/>
+                                                        </tableColumn>
+                                                        <tableColumn identifier="name" width="206" minWidth="40" maxWidth="800" id="8sJ-Ld-Nk8">
+                                                            <tableHeaderCell key="headerCell" lineBreakMode="truncatingTail" borderStyle="border" alignment="left">
+                                                                <font key="font" metaFont="smallSystem"/>
+                                                                <color key="textColor" name="headerTextColor" catalog="System" colorSpace="catalog"/>
+                                                                <color key="backgroundColor" name="headerColor" catalog="System" colorSpace="catalog"/>
+                                                            </tableHeaderCell>
+                                                            <textFieldCell key="dataCell" lineBreakMode="truncatingTail" selectable="YES" editable="YES" alignment="left" title="Text Cell" id="e50-bV-iuP">
+                                                                <font key="font" metaFont="system"/>
+                                                                <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
+                                                                <color key="backgroundColor" name="controlBackgroundColor" catalog="System" colorSpace="catalog"/>
+                                                            </textFieldCell>
+                                                            <tableColumnResizingMask key="resizingMask" resizeWithTable="YES" userResizable="YES"/>
+                                                        </tableColumn>
+                                                        <tableColumn identifier="edit" width="64" minWidth="10" maxWidth="3.4028234663852886e+38" id="97k-Mg-EcW">
+                                                            <tableHeaderCell key="headerCell" lineBreakMode="truncatingTail" borderStyle="border" alignment="left">
+                                                                <font key="font" metaFont="smallSystem"/>
+                                                                <color key="textColor" name="headerTextColor" catalog="System" colorSpace="catalog"/>
+                                                                <color key="backgroundColor" name="headerColor" catalog="System" colorSpace="catalog"/>
+                                                            </tableHeaderCell>
+                                                            <buttonCell key="dataCell" type="push" title="Edit" bezelStyle="rounded" alignment="center" controlSize="small" borderStyle="border" inset="2" id="kOU-Sh-bhq">
+                                                                <behavior key="behavior" pushIn="YES" lightByBackground="YES" lightByGray="YES"/>
+                                                                <font key="font" metaFont="smallSystem"/>
+                                                                <connections>
+                                                                    <action selector="triggerTableViewEditTapped:" target="jsB-SK-wde" id="wif-g0-T01"/>
+                                                                </connections>
+                                                            </buttonCell>
+                                                            <tableColumnResizingMask key="resizingMask" resizeWithTable="YES" userResizable="YES"/>
+                                                        </tableColumn>
+                                                        <tableColumn identifier="delete" width="95" minWidth="10" maxWidth="3.4028234663852886e+38" id="35j-QK-cez">
+                                                            <tableHeaderCell key="headerCell" lineBreakMode="truncatingTail" borderStyle="border" alignment="left">
+                                                                <font key="font" metaFont="smallSystem"/>
+                                                                <color key="textColor" name="headerTextColor" catalog="System" colorSpace="catalog"/>
+                                                                <color key="backgroundColor" name="headerColor" catalog="System" colorSpace="catalog"/>
+                                                            </tableHeaderCell>
+                                                            <buttonCell key="dataCell" type="push" title="Delete" bezelStyle="rounded" alignment="center" controlSize="small" borderStyle="border" inset="2" id="fWM-kE-dnO">
+                                                                <behavior key="behavior" pushIn="YES" lightByBackground="YES" lightByGray="YES"/>
+                                                                <font key="font" metaFont="smallSystem"/>
+                                                                <connections>
+                                                                    <action selector="triggerTableViewDeleteTapped:" target="jsB-SK-wde" id="PiA-sU-4l0"/>
+                                                                </connections>
+                                                            </buttonCell>
+                                                            <tableColumnResizingMask key="resizingMask" resizeWithTable="YES" userResizable="YES"/>
+                                                        </tableColumn>
+                                                    </tableColumns>
+                                                    <connections>
+                                                        <outlet property="dataSource" destination="jsB-SK-wde" id="uPf-X3-j1d"/>
+                                                        <outlet property="delegate" destination="jsB-SK-wde" id="XTJ-D9-g4d"/>
+                                                    </connections>
+                                                </tableView>
+                                            </subviews>
+                                            <color key="backgroundColor" name="controlBackgroundColor" catalog="System" colorSpace="catalog"/>
+                                        </clipView>
+                                        <scroller key="horizontalScroller" hidden="YES" verticalHuggingPriority="750" horizontal="YES" id="w9b-Cd-gDV">
+                                            <rect key="frame" x="1" y="313" width="398" height="16"/>
+                                            <autoresizingMask key="autoresizingMask"/>
+                                        </scroller>
+                                        <scroller key="verticalScroller" hidden="YES" verticalHuggingPriority="750" horizontal="NO" id="wrs-ho-oy9">
+                                            <rect key="frame" x="483" y="1" width="16" height="0.0"/>
+                                            <autoresizingMask key="autoresizingMask"/>
+                                        </scroller>
+                                    </scrollView>
+                                    <button verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="PxI-Tw-ddr">
+                                        <rect key="frame" x="69" y="18" width="116" height="25"/>
+                                        <constraints>
+                                            <constraint firstAttribute="width" constant="116" id="4Ro-Si-hqL"/>
+                                        </constraints>
+                                        <buttonCell key="cell" type="roundTextured" title="Done" bezelStyle="texturedRounded" alignment="center" state="on" borderStyle="border" imageScaling="proportionallyDown" inset="2" id="MbZ-Ae-8pf">
+                                            <behavior key="behavior" pushIn="YES" lightByBackground="YES" lightByGray="YES"/>
+                                            <font key="font" metaFont="system"/>
+                                        </buttonCell>
+                                        <connections>
+                                            <action selector="doneButtonClicked:" target="jsB-SK-wde" id="gYa-O7-4nz"/>
+                                        </connections>
+                                    </button>
+                                    <button verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="bXU-V5-qgD">
+                                        <rect key="frame" x="266" y="18" width="116" height="25"/>
+                                        <constraints>
+                                            <constraint firstAttribute="width" constant="116" id="bkY-RQ-ZTc"/>
+                                        </constraints>
+                                        <buttonCell key="cell" type="roundTextured" title="Cancel" bezelStyle="texturedRounded" alignment="center" state="on" borderStyle="border" imageScaling="proportionallyDown" inset="2" id="P6g-vz-X0A">
+                                            <behavior key="behavior" pushIn="YES" lightByBackground="YES" lightByGray="YES"/>
+                                            <font key="font" metaFont="system"/>
+                                        </buttonCell>
+                                        <connections>
+                                            <action selector="cancelButtonClicked:" target="jsB-SK-wde" id="byY-Ji-LUm"/>
+                                        </connections>
+                                    </button>
+                                </subviews>
+                                <constraints>
+                                    <constraint firstAttribute="bottom" secondItem="PxI-Tw-ddr" secondAttribute="bottom" constant="20" id="2Aj-6P-tq3"/>
+                                    <constraint firstItem="nCz-IJ-jMn" firstAttribute="top" secondItem="axw-TQ-grG" secondAttribute="bottom" constant="8" id="9JI-Ek-0TW"/>
+                                    <constraint firstAttribute="trailing" secondItem="nCz-IJ-jMn" secondAttribute="trailing" constant="50" id="9eN-dP-2Gq"/>
+                                    <constraint firstItem="axw-TQ-grG" firstAttribute="centerX" secondItem="KsX-bi-gGE" secondAttribute="centerX" id="Lbn-96-MLR"/>
+                                    <constraint firstItem="bXU-V5-qgD" firstAttribute="centerY" secondItem="PxI-Tw-ddr" secondAttribute="centerY" id="PND-zM-m2E"/>
+                                    <constraint firstItem="PxI-Tw-ddr" firstAttribute="leading" secondItem="KsX-bi-gGE" secondAttribute="leading" constant="69" id="T5b-jQ-ZP6"/>
+                                    <constraint firstItem="axw-TQ-grG" firstAttribute="top" secondItem="KsX-bi-gGE" secondAttribute="top" constant="20" id="Y5S-qY-d7i"/>
+                                    <constraint firstItem="bXU-V5-qgD" firstAttribute="leading" secondItem="PxI-Tw-ddr" secondAttribute="trailing" constant="81" id="gxu-lN-NvC"/>
+                                    <constraint firstItem="nCz-IJ-jMn" firstAttribute="leading" secondItem="KsX-bi-gGE" secondAttribute="leading" constant="50" id="kDO-g8-E2r"/>
+                                    <constraint firstItem="PxI-Tw-ddr" firstAttribute="top" secondItem="nCz-IJ-jMn" secondAttribute="bottom" constant="18" id="qH5-Lg-AcJ"/>
+                                </constraints>
+                            </customView>
+                        </subviews>
+                        <constraints>
+                            <constraint firstItem="KsX-bi-gGE" firstAttribute="width" secondItem="iga-ba-WIk" secondAttribute="width" id="7gJ-k5-XOo"/>
+                            <constraint firstAttribute="bottom" secondItem="KsX-bi-gGE" secondAttribute="bottom" id="9Q0-ji-aRt"/>
+                            <constraint firstItem="KsX-bi-gGE" firstAttribute="top" secondItem="iga-ba-WIk" secondAttribute="top" id="JRe-q5-cqj"/>
+                            <constraint firstItem="KsX-bi-gGE" firstAttribute="leading" secondItem="iga-ba-WIk" secondAttribute="leading" id="ZNP-L7-2DK"/>
+                        </constraints>
+                    </view>
+                    <connections>
+                        <outlet property="cancelButton" destination="bXU-V5-qgD" id="iRV-3i-yTD"/>
+                        <outlet property="doneButton" destination="PxI-Tw-ddr" id="CIX-DK-L4O"/>
+                        <outlet property="triggersListContainerView" destination="KsX-bi-gGE" id="Dij-4K-xOo"/>
+                        <outlet property="triggersListContainerViewLeadingConstraint" destination="ZNP-L7-2DK" id="ZH2-7I-hHD"/>
+                        <outlet property="triggersTableView" destination="tI3-HF-LAH" id="VHd-SB-cRM"/>
+                    </connections>
+                </viewController>
+                <customObject id="bPy-yB-waX" userLabel="First Responder" customClass="NSResponder" sceneMemberID="firstResponder"/>
+            </objects>
+            <point key="canvasLocation" x="2050" y="1018"/>
         </scene>
     </scenes>
     <resources>

--- a/Buildasaur/Base.lproj/Main.storyboard
+++ b/Buildasaur/Base.lproj/Main.storyboard
@@ -1963,11 +1963,11 @@ Gw
                                     <stackView distribution="fill" orientation="horizontal" alignment="top" horizontalStackHuggingPriority="249.99998474121094" verticalStackHuggingPriority="249.99998474121094" detachesHiddenViews="YES" translatesAutoresizingMaskIntoConstraints="NO" id="yyH-7f-chi">
                                         <rect key="frame" x="9" y="97" width="412" height="56"/>
                                         <subviews>
-                                            <stackView distribution="fill" orientation="vertical" alignment="leading" horizontalStackHuggingPriority="249.99998474121094" verticalStackHuggingPriority="249.99998474121094" detachesHiddenViews="YES" translatesAutoresizingMaskIntoConstraints="NO" id="Yp3-gn-PeT">
-                                                <rect key="frame" x="0.0" y="1" width="54" height="54"/>
+                                            <stackView distribution="fill" orientation="vertical" alignment="leading" horizontalStackHuggingPriority="249.99998474121094" verticalStackHuggingPriority="249.99998474121094" misplaced="YES" detachesHiddenViews="YES" translatesAutoresizingMaskIntoConstraints="NO" id="Yp3-gn-PeT">
+                                                <rect key="frame" x="0.0" y="0.0" width="54" height="55"/>
                                                 <subviews>
-                                                    <textField horizontalHuggingPriority="251" verticalHuggingPriority="749" translatesAutoresizingMaskIntoConstraints="NO" id="44T-kR-MXL">
-                                                        <rect key="frame" x="-2" y="29" width="58" height="25"/>
+                                                    <textField horizontalHuggingPriority="251" verticalHuggingPriority="749" misplaced="YES" translatesAutoresizingMaskIntoConstraints="NO" id="44T-kR-MXL">
+                                                        <rect key="frame" x="-2" y="29" width="58" height="26"/>
                                                         <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" alignment="right" title="Triggers:" id="UDU-ml-1bK">
                                                             <font key="font" metaFont="system"/>
                                                             <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
@@ -2080,8 +2080,8 @@ Gw
                                             </scrollView>
                                         </subviews>
                                         <constraints>
+                                            <constraint firstItem="Yp3-gn-PeT" firstAttribute="bottom" secondItem="Pzv-da-4vI" secondAttribute="bottom" id="M6p-yc-JNY"/>
                                             <constraint firstItem="Yp3-gn-PeT" firstAttribute="top" secondItem="3LH-7K-zWF" secondAttribute="top" id="cYC-wG-Uz7"/>
-                                            <constraint firstItem="Yp3-gn-PeT" firstAttribute="bottom" secondItem="3LH-7K-zWF" secondAttribute="bottom" id="ebm-OQ-UdX"/>
                                         </constraints>
                                         <visibilityPriorities>
                                             <integer value="1000"/>
@@ -2615,7 +2615,7 @@ Gw
                                             <real value="3.4028234663852886e+38"/>
                                         </customSpacing>
                                     </stackView>
-                                    <stackView distribution="fillEqually" orientation="horizontal" alignment="top" spacing="20" horizontalStackHuggingPriority="249.99998474121094" verticalStackHuggingPriority="249.99998474121094" misplaced="YES" detachesHiddenViews="YES" translatesAutoresizingMaskIntoConstraints="NO" id="Yy1-w8-4AT">
+                                    <stackView distribution="fillEqually" orientation="horizontal" alignment="top" spacing="20" horizontalStackHuggingPriority="249.99998474121094" verticalStackHuggingPriority="249.99998474121094" detachesHiddenViews="YES" translatesAutoresizingMaskIntoConstraints="NO" id="Yy1-w8-4AT">
                                         <rect key="frame" x="95" y="0.0" width="220" height="22"/>
                                         <subviews>
                                             <button verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="IQl-Cn-uMh">
@@ -3558,7 +3558,7 @@ Gw
                                             <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                                             <subviews>
                                                 <tableView verticalHuggingPriority="750" allowsExpansionToolTips="YES" columnAutoresizingStyle="lastColumnOnly" selectionHighlightStyle="none" alternatingRowBackgroundColors="YES" columnReordering="NO" multipleSelection="NO" autosaveColumns="NO" typeSelect="NO" id="tI3-HF-LAH">
-                                                    <rect key="frame" x="0.0" y="0.0" width="398" height="328"/>
+                                                    <rect key="frame" x="0.0" y="0.0" width="397" height="19"/>
                                                     <autoresizingMask key="autoresizingMask"/>
                                                     <size key="intercellSpacing" width="3" height="2"/>
                                                     <color key="backgroundColor" name="controlBackgroundColor" catalog="System" colorSpace="catalog"/>

--- a/Buildasaur/BuildTemplateViewController.swift
+++ b/Buildasaur/BuildTemplateViewController.swift
@@ -529,12 +529,12 @@ class BuildTemplateViewController: ConfigEditViewController, NSTableViewDataSour
     }
 
     @IBAction func addTriggerButtonClicked(sender: AnyObject) {
-        let buttons = ["Add new", "Add existed", "Cancel"]
-        UIUtils.showAlertWithButtons("Would you like to add a new trigger or add existed one?", buttons: buttons, style: NSAlertStyle.InformationalAlertStyle, completion: { (tappedButton) -> () in
+        let buttons = ["Add new", "Add existing", "Cancel"]
+        UIUtils.showAlertWithButtons("Would you like to add a new trigger or add existing one?", buttons: buttons, style: NSAlertStyle.InformationalAlertStyle, completion: { (tappedButton) -> () in
             switch (tappedButton) {
             case "Add new":
                 self.editTrigger(nil)
-            case "Add existed":
+            case "Add existing":
                 self.performSegueWithIdentifier("selectTriggers", sender: nil)
             default: break
             }

--- a/Buildasaur/SelectTriggerViewController.swift
+++ b/Buildasaur/SelectTriggerViewController.swift
@@ -1,0 +1,182 @@
+//
+//  SelectTriggerViewController.swift
+//  Buildasaur
+//
+//  Created by Anton Domashnev on 23/06/16.
+//  Copyright © 2016 Honza Dvorsky. All rights reserved.
+//
+
+import Foundation
+import AppKit
+import XcodeServerSDK
+import ReactiveCocoa
+import BuildaKit
+
+
+protocol SelectTriggerViewControllerDelegate: class {
+    func selectTriggerViewController(viewController: SelectTriggerViewController, didSelectTriggers selectedTriggers: [TriggerConfig])
+}
+
+class SelectTriggerViewController: NSViewController, NSTableViewDelegate, NSTableViewDataSource {
+    
+    weak var delegate: SelectTriggerViewControllerDelegate?
+    
+    @IBOutlet weak var triggersListContainerViewLeadingConstraint: NSLayoutConstraint!
+    @IBOutlet weak var triggersListContainerView: NSView!
+    @IBOutlet weak var triggersTableView: NSTableView!
+    @IBOutlet weak var doneButton: NSButton!
+    @IBOutlet weak var cancelButton: NSButton!
+    
+    var storageManager: StorageManager!
+    
+    private let triggers = MutableProperty<[TriggerConfig]>([])
+    private let selectedTriggerIDs = MutableProperty<[String]>([])
+    
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        self.setupBindings()
+        self.fetchTriggers()
+        self.selectedTriggerIDs.value = []
+        
+    }
+    
+    private func setupBindings() {
+        self.triggers.producer.startWithNext { [weak self] _ in
+            self?.triggersTableView.reloadData()
+        }
+        self.selectedTriggerIDs.producer.startWithNext { [weak self] _ in
+            self?.doneButton.enabled = self?.selectedTriggerIDs.value.count > 0
+        }
+    }
+    
+    //MARK: triggers table view
+    
+    func numberOfRowsInTableView(tableView: NSTableView) -> Int {
+        return self.triggers.value.count
+    }
+    
+    func tableView(tableView: NSTableView, objectValueForTableColumn tableColumn: NSTableColumn?, row: Int) -> AnyObject? {
+        let triggers = self.triggers.value
+        let trigger = triggers[row]
+        switch tableColumn!.identifier {
+        case "name":
+            return trigger.name
+        case "selected":
+            let index = self.selectedTriggerIDs.value
+                .indexOfFirstObjectPassingTest { $0 == trigger.id }
+            let enabled = index > -1
+            return enabled
+        default:
+            return nil
+        }
+    }
+    
+    func tableView(tableView: NSTableView, shouldSelectTableColumn tableColumn: NSTableColumn?) -> Bool {
+        return false
+    }
+    
+    @IBAction func triggersTableViewRowCheckboxTapped(sender: AnyObject) {
+        let trigger = self.triggers.value[self.triggersTableView.selectedRow]
+        let foundIndex = self.selectedTriggerIDs.value.indexOfFirstObjectPassingTest({ $0 == trigger.id })
+        
+        if let foundIndex = foundIndex {
+            self.selectedTriggerIDs.value.removeAtIndex(foundIndex)
+        } else {
+            self.selectedTriggerIDs.value.append(trigger.id)
+        }
+    }
+    
+    @IBAction func triggerTableViewEditTapped(sender: AnyObject) {
+        let index = self.triggersTableView.selectedRow
+        let trigger = self.triggers.value[index]
+        self.editTrigger(trigger)
+    }
+    
+    @IBAction func triggerTableViewDeleteTapped(sender: AnyObject) {
+        let index = self.triggersTableView.selectedRow
+        let trigger = self.triggers.value[index]
+        self.storageManager.removeTriggerConfig(trigger)
+        self.triggers.value.removeAtIndex(index)
+    }
+ 
+    //MARK: helpers
+    
+    func editTrigger(trigger: TriggerConfig?) {
+        let triggerViewController = NSStoryboard.mainStoryboard.instantiateControllerWithIdentifier(TriggerViewController.storyboardID) as! TriggerViewController
+        triggerViewController.triggerConfig.value = trigger
+        triggerViewController.storageManager = self.storageManager
+        triggerViewController.delegate = self
+        self.pushTriggerViewController(triggerViewController)
+    }
+    
+    func fetchTriggers() {
+        self.triggers.value = self.storageManager.triggerConfigs.value.map { $0.1 }
+    }
+    
+    func pushTriggerViewController(viewController: TriggerViewController) {
+        self.addChildViewController(viewController)
+        self.view.addSubview(viewController.view)
+        
+        let pushingView = viewController.view
+        let mainLeadingConstraint = self.triggersListContainerViewLeadingConstraint
+        let endPushingViewFrame = pushingView.frame
+        pushingView.frame = CGRectOffset(pushingView.frame, CGRectGetWidth(pushingView.frame), 0)
+        
+        NSAnimationContext.runAnimationGroup({ (context: NSAnimationContext) -> Void in
+            
+            context.duration = 0.3
+            pushingView.animator().frame = endPushingViewFrame
+            mainLeadingConstraint.animator().constant = -CGRectGetWidth(pushingView.frame)
+            
+        }) { /* do nothing */ }
+    }
+    
+    func popTriggerViewController(viewController: TriggerViewController) {
+        let poppingView = viewController.view
+        let mainLeadingConstraint = self.triggersListContainerViewLeadingConstraint
+        let endPoppingViewFrame = CGRectOffset(poppingView.frame, CGRectGetWidth(poppingView.frame), 0)
+        
+        NSAnimationContext.runAnimationGroup({ (context: NSAnimationContext) -> Void in
+            
+            context.duration = 0.3
+            poppingView.animator().frame = endPoppingViewFrame
+            mainLeadingConstraint.animator().constant = 0
+            
+        }) {
+            
+            poppingView.removeFromSuperview()
+            viewController.removeFromParentViewController()
+        }
+    }
+    
+    //MARK: actions
+    
+    @IBAction func doneButtonClicked(sender: NSButton) {
+        
+        let dictionarifyAvailableTriggers: [String: TriggerConfig] = self.triggers.value.dictionarifyWithKey {$0.id}
+        let selectedTriggers: [TriggerConfig] = self.selectedTriggerIDs.value.map { dictionarifyAvailableTriggers[$0]! }
+        self.delegate?.selectTriggerViewController(self, didSelectTriggers: selectedTriggers)
+        self.dismissController(nil)
+    }
+    
+    @IBAction func cancelButtonClicked(sender: NSButton) {
+        
+        self.dismissController(nil)
+    }
+    
+}
+
+extension SelectTriggerViewController: TriggerViewControllerDelegate {
+    
+    func triggerViewController(triggerViewController: NSViewController, didCancelEditingTrigger trigger: TriggerConfig) {
+        self.popTriggerViewController(triggerViewController as! TriggerViewController)
+    }
+    
+    func triggerViewController(triggerViewController: NSViewController, didSaveTrigger trigger: TriggerConfig) {
+        var mapped = self.triggers.value.dictionarifyWithKey { $0.id }
+        mapped[trigger.id] = trigger
+        self.triggers.value = Array(mapped.values)
+        self.popTriggerViewController(triggerViewController as! TriggerViewController)
+    }
+
+}

--- a/Buildasaur/TriggerViewController.swift
+++ b/Buildasaur/TriggerViewController.swift
@@ -14,11 +14,13 @@ import ReactiveCocoa
 import Result
 
 protocol TriggerViewControllerDelegate: class {
-    func triggerViewControllerDidCancelEditingTrigger(trigger: TriggerConfig)
-    func triggerViewControllerDidSaveTrigger(trigger: TriggerConfig)
+    func triggerViewController(triggerViewController: NSViewController, didCancelEditingTrigger trigger: TriggerConfig)
+    func triggerViewController(triggerViewController: NSViewController, didSaveTrigger trigger: TriggerConfig)
 }
 
 class TriggerViewController: NSViewController {
+    
+    static let storyboardID: String = "triggerViewController"
     
     let triggerConfig = MutableProperty<TriggerConfig!>(nil)
     var storageManager: StorageManager!
@@ -26,6 +28,8 @@ class TriggerViewController: NSViewController {
     weak var delegate: TriggerViewControllerDelegate?
     
     @IBOutlet weak var saveButton: NSButton!
+    @IBOutlet weak var cancelButton: NSButton!
+    @IBOutlet weak var closeButton: NSButton!
     @IBOutlet weak var nameTextField: NSTextField!
     @IBOutlet weak var kindPopup: NSPopUpButton!
     @IBOutlet weak var phasePopup: NSPopUpButton!
@@ -68,7 +72,7 @@ class TriggerViewController: NSViewController {
         self.setupLabels()
         self.setupConditions()
         self.setupEmailConfiguration()
-
+        
         //initial dump
         
         self.triggerConfig.producer.startWithNext { [weak self] config in
@@ -324,10 +328,7 @@ class TriggerViewController: NSViewController {
         self.storageManager.addTriggerConfig(currentTrigger)
         
         //notify delegate
-        self.delegate?.triggerViewControllerDidSaveTrigger(currentTrigger)
-        
-        //dismiss
-        self.dismissController(nil)
+        self.delegate?.triggerViewController(self, didSaveTrigger: currentTrigger)
     }
     
     @IBAction func cancelButtonClicked(sender: NSButton) {
@@ -335,8 +336,7 @@ class TriggerViewController: NSViewController {
         //in case of cancel we could never have had a valid trigger, so just
         //use the original trigger in that case. we only care about the id anyway.
         let currentTrigger = self.generatedTrigger.value ?? self.triggerConfig.value!
-        self.delegate?.triggerViewControllerDidCancelEditingTrigger(currentTrigger)
-        self.dismissController(nil)
+        self.delegate?.triggerViewController(self, didCancelEditingTrigger: currentTrigger)
     }
     
     //MARK: consts


### PR DESCRIPTION
Hi All,
First of all thanks for the great tool @czechboy0, it really rocks!

In my current setup, I have four syncers that are using two same triggers. And to create those triggers I had to write same things four times, to improve the UX for that kind of setup I would like to introduce the screen to select trigger from already created triggers list.

Thit PR makes following changes:
- if the user clicks `+` button to add a trigger to the template the alert will appear with an option to select from already existed or create a new one ![image](https://api.monosnap.com/rpc/file/download?id=7y2eVIFF2tn2BkDjdzTMC19ZWLFJ5T)
- If the user clicks the `Add existed` new screen will appear with the list of all available triggers ![image](https://api.monosnap.com/rpc/file/download?id=bIGawxiKBd7ZFZn6MB5Kk6BeoNxwbV) On that screen user can select multiple triggers to add to the template, the user can edit specific trigger or delete or from the database.
- On the build template screen in triggers table view now `delete` button only removes the trigger from the table view but not from the database.

Looking forward to hearing your thoughts.

P.S. also have the following idea to have predefined triggers already in Builda, so user doesn't have to type run script for CocoaPods or etc.
