### PR TITLE
Sketch for Xcode Server discovery using Bonjour

### DIFF
--- a/BuildaKit/BonjourUtils.swift
+++ b/BuildaKit/BonjourUtils.swift
@@ -1,0 +1,84 @@
+//
+//  BonjourUtils.swift
+//  Buildasaur
+//
+//  Created by Seán Labastille on 17/08/16.
+//  Copyright © 2016 Honza Dvorsky. All rights reserved.
+//
+
+import BuildaUtils
+
+public class BonjourUtilsTester {
+    public class func dumpXcodeServers() {
+        BonjourUtils.startDiscoveringXcodeServersAdvertisedOnBonjour()
+    }
+}
+
+private protocol BonjourUtilsDelegate: class {
+    func didDiscoverXcodeServer(service: NSNetService)
+    func didRemoveXcodeServer(service: NSNetService)
+}
+
+/* Wraps NSNetService browsing to discover Xcode Server instances.
+ * Service browsing needs to be started and stopped.
+ * Once a service is found it needs to be resolved, at which point it can be used by clients.
+ */
+private class BonjourUtils {
+
+    private static let browser = NSNetServiceBrowser()
+    private static let browserDelegate = XcodeServerBrowserDelegate()
+    private static weak var delegate: BonjourUtilsDelegate?
+
+    private class func startDiscoveringXcodeServersAdvertisedOnBonjour() {
+        browser.delegate = browserDelegate
+        browser.searchForServicesOfType("_xcs2p._tcp.", inDomain: "local.")
+    }
+
+    private class func stopDiscoveringXcodeServersAdvertisedOnBonjour() {
+        browser.stop()
+    }
+
+    private class XcodeServerBrowserDelegate: NSObject, NSNetServiceBrowserDelegate, NSNetServiceDelegate {
+        private var services = [NSNetService]()
+
+        @objc private func netServiceBrowserWillSearch(browser: NSNetServiceBrowser) { }
+
+        @objc private func netServiceBrowserDidStopSearch(browser: NSNetServiceBrowser) { }
+
+        @objc private func netServiceBrowser(browser: NSNetServiceBrowser, didNotSearch errorDict: [String : NSNumber]) { }
+
+        @objc private func netServiceBrowser(browser: NSNetServiceBrowser, didFindService service: NSNetService, moreComing: Bool) {
+            service.resolveWithTimeout(10)
+            service.delegate = self
+            services.append(service)
+            Log.info("Found Xcode Server Service: \(service)")
+            if !moreComing {
+
+            }
+        }
+
+        @objc private func netServiceBrowser(browser: NSNetServiceBrowser, didRemoveService service: NSNetService, moreComing: Bool) {
+            if let index = services.indexOf(service) {
+                Log.info("Removing Xcode Server Service: \(service)")
+                delegate?.didRemoveXcodeServer(service)
+                services.removeAtIndex(index)
+            }
+
+            if !moreComing {
+
+            }
+        }
+
+        @objc private func netServiceWillResolve(sender: NSNetService) { }
+
+        @objc private func netServiceDidResolveAddress(sender: NSNetService) {
+            if sender.addresses?.count > 0 {
+                sender.stop()
+                Log.info("Resolved Xcode Server Service: \(sender.hostName ?? ""):\(sender.port)")
+                delegate?.didDiscoverXcodeServer(sender)
+            }
+        }
+        
+        @objc private func netService(sender: NSNetService, didNotResolve errorDict: [String : NSNumber]) { }
+    }
+}

--- a/BuildaKit/BonjourUtils.swift
+++ b/BuildaKit/BonjourUtils.swift
@@ -15,8 +15,7 @@ public class BonjourUtilsTester {
 }
 
 private protocol BonjourUtilsDelegate: class {
-    func didDiscoverXcodeServer(service: NSNetService)
-    func didRemoveXcodeServer(service: NSNetService)
+    func discoveredXcodeServers(servers: [NSNetService])
 }
 
 /* Wraps NSNetService browsing to discover Xcode Server instances.
@@ -60,8 +59,8 @@ private class BonjourUtils {
         @objc private func netServiceBrowser(browser: NSNetServiceBrowser, didRemoveService service: NSNetService, moreComing: Bool) {
             if let index = services.indexOf(service) {
                 Log.info("Removing Xcode Server Service: \(service)")
-                delegate?.didRemoveXcodeServer(service)
                 services.removeAtIndex(index)
+                delegate?.discoveredXcodeServers(services)
             }
 
             if !moreComing {
@@ -75,7 +74,7 @@ private class BonjourUtils {
             if sender.addresses?.count > 0 {
                 sender.stop()
                 Log.info("Resolved Xcode Server Service: \(sender.hostName ?? ""):\(sender.port)")
-                delegate?.didDiscoverXcodeServer(sender)
+                delegate?.discoveredXcodeServers(services)
             }
         }
         

--- a/Buildasaur.xcodeproj/project.pbxproj
+++ b/Buildasaur.xcodeproj/project.pbxproj
@@ -9,6 +9,7 @@
 /* Begin PBXBuildFile section */
 		0928E6AF8EED8E829B0F4286 /* Pods_Buildasaur.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 8FA09FE729BC440366D74E2E /* Pods_Buildasaur.framework */; };
 		130C2BB548050F030930B54F /* Pods_BuildaHeartbeatKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 41155620B4193BDB27CD7E83 /* Pods_BuildaHeartbeatKit.framework */; };
+		14E846601D6440FB0067B990 /* BonjourUtils.swift in Sources */ = {isa = PBXBuildFile; fileRef = 14E8465F1D6440FB0067B990 /* BonjourUtils.swift */; };
 		158554341171FBBD63B039E2 /* Pods_BuildaGitServerTests.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = F29FCDBD0B3B9740956E5206 /* Pods_BuildaGitServerTests.framework */; };
 		3A0034F01C5975C000A4ECB5 /* bitbucket_post_status.json in Resources */ = {isa = PBXBuildFile; fileRef = 3A0034EF1C5975C000A4ECB5 /* bitbucket_post_status.json */; };
 		3A0034F21C59775100A4ECB5 /* bitbucket_get_status.json in Resources */ = {isa = PBXBuildFile; fileRef = 3A0034F11C59775100A4ECB5 /* bitbucket_get_status.json */; };
@@ -227,6 +228,7 @@
 
 /* Begin PBXFileReference section */
 		105246397B31495A090CD1D1 /* Pods-BuildaKit.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-BuildaKit.release.xcconfig"; path = "Pods/Target Support Files/Pods-BuildaKit/Pods-BuildaKit.release.xcconfig"; sourceTree = "<group>"; };
+		14E8465F1D6440FB0067B990 /* BonjourUtils.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = BonjourUtils.swift; sourceTree = "<group>"; };
 		2D7FAD09E7CF5F0D5E6CC526 /* Pods-BuildaHeartbeatKit.testing.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-BuildaHeartbeatKit.testing.xcconfig"; path = "Pods/Target Support Files/Pods-BuildaHeartbeatKit/Pods-BuildaHeartbeatKit.testing.xcconfig"; sourceTree = "<group>"; };
 		38739D0E658C834537584B63 /* Pods-BuildaGitServerTests.testing.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-BuildaGitServerTests.testing.xcconfig"; path = "Pods/Target Support Files/Pods-BuildaGitServerTests/Pods-BuildaGitServerTests.testing.xcconfig"; sourceTree = "<group>"; };
 		3A0034EF1C5975C000A4ECB5 /* bitbucket_post_status.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; name = bitbucket_post_status.json; path = Data/bitbucket_post_status.json; sourceTree = "<group>"; };
@@ -820,6 +822,7 @@
 				3ACBADE81B5ADE2A00204457 /* StorageUtils.swift */,
 				3ACBADFB1B5ADE2A00204457 /* XcodeServerSyncerUtils.swift */,
 				3AE4F6CD1BBC88450006CA1C /* RACUtils.swift */,
+				14E8465F1D6440FB0067B990 /* BonjourUtils.swift */,
 			);
 			name = Utils;
 			sourceTree = "<group>";
@@ -1554,6 +1557,7 @@
 				3A395B551BCF007000BB6947 /* LoginItem.swift in Sources */,
 				3A9D741D1BCBDDA200DCA23C /* PersistenceMigrator.swift in Sources */,
 				3ACBAE011B5ADE2A00204457 /* Project.swift in Sources */,
+				14E846601D6440FB0067B990 /* BonjourUtils.swift in Sources */,
 				3ACBAE0D1B5ADE2A00204457 /* SyncPair_PR_Bot.swift in Sources */,
 				3ACBAE031B5ADE2A00204457 /* StorageManager.swift in Sources */,
 				3AD5D2E81BD01EAF008DBB45 /* SummaryBuilder.swift in Sources */,

--- a/Buildasaur/XcodeServerViewController.swift
+++ b/Buildasaur/XcodeServerViewController.swift
@@ -28,7 +28,9 @@ class XcodeServerViewController: ConfigEditViewController {
     
     override func viewDidLoad() {
         super.viewDidLoad()
-        
+
+        BonjourUtilsTester.dumpXcodeServers()
+
         self.setup()
     }
     


### PR DESCRIPTION
This relates to #166 

Since `NSNetServiceBrowser` operates asynchronously using a set of delegate methods for starting and stopping discovery it seems easiest for a client, such as the `XcodeServerViewController` to start discovery and handle servers as they are added or removed.
