### PR TITLE
Hanging on `xcodebuild -showBuildSettings` while creating template

### DIFF
--- a/BuildaKit/XcodeDeviceParser.swift
+++ b/BuildaKit/XcodeDeviceParser.swift
@@ -58,7 +58,7 @@ public class XcodeDeviceParser {
         let folder = projectFolderUrl.URLByDeletingLastPathComponent?.path ?? "~"
         let schemeName = scheme.name
         
-        let script = "cd \"\(folder)\"; xcodebuild \(ownerArgs) -scheme \"\(schemeName)\" -showBuildSettings 2>/dev/null | egrep '^\\s*PLATFORM_NAME' | cut -d = -f 2 | uniq | xargs echo"
+        let script = "cd \"\(folder)\"; xcodebuild clean \(ownerArgs) -scheme \"\(schemeName)\" -showBuildSettings 2>/dev/null | egrep '^\\s*PLATFORM_NAME' | cut -d = -f 2 | uniq | xargs echo"
         let res = Script.runTemporaryScript(script)
         if res.terminationStatus == 0 {
             let deviceType = res.standardOutput.stripTrailingNewline()


### PR DESCRIPTION
Fixes #294
Workaround suggested in https://forums.developer.apple.com/thread/50372

After placing a lot of extra logs I found out that the template creating process hangs on `xcodebuild` shell script written in `XcodeDeviceParser.parseTargetTypeFromSchemeAndProjectAtUrl(...)` function.
Could be non-reproducible on some hosts or under Debug. It wasn't reproduced on my development host with Xcode 8.3.1 but reproduced all the time on remote build server with Xcode 8.2.1.